### PR TITLE
Fix compilation errors with glibc 2.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,4 +198,5 @@ Projects using Seastar
 
 * [cpv-cql-driver](https://github.com/cpv-project/cpv-cql-driver): C++ driver for Cassandra/Scylla based on seastar framework
 * [cpv-framework](https://github.com/cpv-project/cpv-framework): A web framework written in c++ based on seastar framework
-
+* [redpanda](https://vectorized.io/): A Kafka replacement for mission critical systems
+* [smf](https://github.com/smfrpc/smf): The fastest RPC in the West

--- a/README.md
+++ b/README.md
@@ -192,3 +192,10 @@ Recommended hardware configuration for SeaStar
        Both memaslap (memcached) and WRK (httpd) cannot over load their matching
        server counter parts. We recommend running the client on different machine
        than the servers and use several of them.
+
+Projects using Seastar
+----------------------------------------------
+
+* [cpv-cql-driver](https://github.com/cpv-project/cpv-cql-driver): C++ driver for Cassandra/Scylla based on seastar framework
+* [cpv-framework](https://github.com/cpv-project/cpv-framework): A web framework written in c++ based on seastar framework
+

--- a/README.md
+++ b/README.md
@@ -199,4 +199,5 @@ Projects using Seastar
 * [cpv-cql-driver](https://github.com/cpv-project/cpv-cql-driver): C++ driver for Cassandra/Scylla based on seastar framework
 * [cpv-framework](https://github.com/cpv-project/cpv-framework): A web framework written in c++ based on seastar framework
 * [redpanda](https://vectorized.io/): A Kafka replacement for mission critical systems
+* [Scylla](https://github.com/scylladb/scylla): A fast and reliable NoSQL data store compatible with Cassandra and DynamoDB
 * [smf](https://github.com/smfrpc/smf): The fastest RPC in the West

--- a/include/seastar/core/future-util.hh
+++ b/include/seastar/core/future-util.hh
@@ -163,7 +163,7 @@ public:
     void add_exception(std::exception_ptr ex) {
         _ex = std::move(ex);
     }
-    void add_future(future<> f) {
+    void add_future(future<>&& f) {
         _incomplete.push_back(std::move(f));
     }
     future<> get_future() {

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -1043,7 +1043,7 @@ public:
     ///
     /// \return \c true if the future is availble and has failed.
     [[gnu::always_inline]]
-    bool failed() noexcept {
+    bool failed() const noexcept {
         return _state.failed();
     }
 

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -152,7 +152,7 @@ struct uninitialized_wrapper_base<T, false> {
     } _v;
 
 public:
-    void uninitialized_set(T v) {
+    void uninitialized_set(T&& v) {
         new (&_v.value) T(std::move(v));
     }
     T& uninitialized_get() {
@@ -164,7 +164,7 @@ public:
 };
 
 template <typename T> struct uninitialized_wrapper_base<T, true> : private T {
-    void uninitialized_set(T v) {
+    void uninitialized_set(T&& v) {
         new (this) T(std::move(v));
     }
     T& uninitialized_get() {

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -44,6 +44,7 @@ debian_packages=(
     libc-ares-dev
     stow
     g++
+    libfmt-dev
 )
 
 # seastar doesn't directly depend on these packages. They are

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1588,6 +1588,7 @@ int __libc_posix_memalign(void** ptr, size_t align, size_t size) throw ();
 
 extern "C"
 [[gnu::visibility("default")]]
+[[gnu::malloc]]
 void* memalign(size_t align, size_t size) throw () {
     if (try_trigger_error_injector()) {
         return nullptr;

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1589,6 +1589,9 @@ int __libc_posix_memalign(void** ptr, size_t align, size_t size) throw ();
 extern "C"
 [[gnu::visibility("default")]]
 [[gnu::malloc]]
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 30)
+[[gnu::alloc_size(2)]]
+#endif
 void* memalign(size_t align, size_t size) throw () {
     if (try_trigger_error_injector()) {
         return nullptr;
@@ -1610,6 +1613,9 @@ extern "C"
 [[gnu::alias("memalign")]]
 [[gnu::visibility("default")]]
 [[gnu::malloc]]
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 30)
+[[gnu::alloc_size(2)]]
+#endif
 void* __libc_memalign(size_t align, size_t size) throw ();
 
 extern "C"

--- a/src/net/socket_address.cc
+++ b/src/net/socket_address.cc
@@ -51,7 +51,7 @@ socket_address::socket_address(const unix_domain_addr& s) {
     memset(u.un.sun_path, '\0', sizeof(u.un.sun_path));
     auto path_length = std::min((int)sizeof(u.un.sun_path), s.path_length());
     memcpy(u.un.sun_path, s.path_bytes(), path_length);
-    addr_length = path_length + ((size_t) (((struct ::sockaddr_un *) 0)->sun_path));
+    addr_length = path_length + offsetof(struct ::sockaddr_un, sun_path);
 }
 
 std::string unix_domain_addr_text(const socket_address& sa) {

--- a/src/util/log.cc
+++ b/src/util/log.cc
@@ -158,7 +158,7 @@ logger::~logger() {
 }
 
 void
-logger::really_do_log(log_level level, const char* fmt, const stringer* s, size_t n) {
+logger::really_do_log(log_level level, const char* fmt, const stringer* stringers, size_t stringers_size) {
     bool is_stdout_enabled = _stdout.load(std::memory_order_relaxed);
     bool is_syslog_enabled = _syslog.load(std::memory_order_relaxed);
     if(!is_stdout_enabled && !is_syslog_enabled) {
@@ -179,6 +179,8 @@ logger::really_do_log(log_level level, const char* fmt, const stringer* s, size_
         out << " " << _name << " - ";
       }
       const char* p = fmt;
+      size_t n = stringers_size;
+      const stringer* s = stringers;
       while (*p != '\0') {
         if (*p == '{' && *(p+1) == '}') {
             p += 2;

--- a/tests/unit/unix_domain_test.cc
+++ b/tests/unit/unix_domain_test.cc
@@ -110,7 +110,7 @@ future<> ud_server_client::client_round() {
             [this,&out,&inp](){ return out.flush(); }).then(
             [this,&out,&inp](){ return inp.read(); }).then(
             [this,&out,&inp](auto bb){
-                BOOST_REQUIRE_EQUAL(bb.get(), "+"s+test_message);
+                BOOST_REQUIRE_EQUAL(compat::string_view(bb.begin(), bb.size()), "+"s+test_message);
                 return inp.close();
             }).then([&out](){return out.close();}).then(
             [&out,&inp]{ return make_ready_future<>(); });


### PR DESCRIPTION
I could not compile the current version of seastar because of lack of this change: https://github.com/scylladb/seastar/commit/8ea42917f1e2aae704f42f1239703a134f868800