### PR TITLE
Kafka TCP connection class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,8 @@ add_library (seastar STATIC
   src/http/transformers.cc
   src/json/formatter.cc
   src/json/json_elements.cc
+  src/kafka/connection/tcp_connection.hh
+  src/kafka/connection/tcp_connection.cc
   src/net/arp.cc
   src/net/config.cc
   src/net/dhcp.cc

--- a/src/kafka/connection/tcp_connection.cc
+++ b/src/kafka/connection/tcp_connection.cc
@@ -1,0 +1,58 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#include "tcp_connection.hh"
+
+namespace seastar {
+
+namespace kafka {
+
+future<lw_shared_ptr<tcp_connection>> tcp_connection::connect(const std::string& host, uint16_t port) {
+    net::inet_address target_host = net::inet_address{host};
+    sa_family_t family = target_host.is_ipv4() ? sa_family_t(AF_INET) : sa_family_t(AF_INET6);
+    socket_address socket = socket_address(::sockaddr_in{family, INADDR_ANY, {0}});
+    auto f = target_host.is_ipv4()
+            ? engine().net().connect(ipv4_addr{target_host, port}, socket, transport::TCP)
+            : engine().net().connect(ipv6_addr{target_host, port}, socket, transport::TCP);
+    return f.then([target_host = std::move(target_host), port] (connected_socket fd) {
+                return make_lw_shared<tcp_connection>(target_host, port, std::move(fd));
+            }
+    );
+}
+
+future<temporary_buffer<char>> tcp_connection::read(size_t bytes) {
+    return _read_buf.read_exactly(bytes);
+}
+
+future<> tcp_connection::write(temporary_buffer<char> buff) {
+    return _write_buf.write(std::move(buff)).then([this] {
+        return _write_buf.flush();
+    });
+}
+
+future<> tcp_connection::close() {
+    return when_all(_read_buf.close(), _write_buf.close()).discard_result();
+}
+
+}
+
+}

--- a/src/kafka/connection/tcp_connection.hh
+++ b/src/kafka/connection/tcp_connection.hh
@@ -1,0 +1,63 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/net/net.hh>
+#include <seastar/net/inet_address.hh>
+#include <string>
+
+namespace seastar {
+
+namespace kafka {
+
+class tcp_connection {
+
+    net::inet_address _host;
+    uint16_t _port;
+    connected_socket _fd;
+    input_stream<char> _read_buf;
+    output_stream<char> _write_buf;
+
+public:
+
+    static future<lw_shared_ptr<tcp_connection>> connect(const std::string& host, uint16_t port);
+
+    tcp_connection(const net::inet_address& host, uint16_t port, connected_socket&& fd) noexcept
+            : _host(host)
+            , _port(port)
+            , _fd(std::move(fd))
+            , _read_buf(_fd.input())
+            , _write_buf(_fd.output()) {};
+
+    tcp_connection(tcp_connection&& other) = default;
+
+    future<> write(temporary_buffer<char> buff);
+    future<temporary_buffer<char>> read(size_t bytes);
+    future<> close();
+
+};
+
+}
+
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -312,6 +312,9 @@ seastar_add_test (network_interface
 seastar_add_test (json_formatter
   SOURCES json_formatter_test.cc)
 
+seastar_add_test (kafka_connection
+  SOURCES kafka_connection_test.cc)
+
 seastar_add_test (lowres_clock
   SOURCES lowres_clock_test.cc)
 

--- a/tests/unit/kafka_connection_test.cc
+++ b/tests/unit/kafka_connection_test.cc
@@ -1,0 +1,83 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Copyright (C) 2019 ScyllaDB Ltd.
+ */
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/testing/test_runner.hh>
+#include "../../src/kafka/connection/tcp_connection.hh"
+
+using namespace seastar;
+
+// All of the tests below assume that there is a Kafka broker running
+// on address BROKER_ADDRESS
+constexpr char BROKER_ADDRESS[] = "172.13.0.1";
+constexpr uint16_t PORT = 9092;
+
+constexpr char message_str[] = "\x00\x00\x00\x0E\x00\x12\x00\x02\x00\x00\x00\x00\x00\x04\x74\x65\x73\x74";
+constexpr size_t message_len = sizeof(message_str);
+
+SEASTAR_THREAD_TEST_CASE(kafka_establish_connection_test) {
+    kafka::tcp_connection::connect(BROKER_ADDRESS, PORT).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(kafka_connection_write_without_errors_test) {
+    temporary_buffer<char> message {message_str, message_len};
+
+    auto conn = kafka::tcp_connection::connect(BROKER_ADDRESS, PORT).get0();
+    conn->write(message.clone()).get();
+    conn->close().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(kafka_connection_read_without_errors_test) {
+    return;
+}
+
+SEASTAR_THREAD_TEST_CASE(kafka_connection_successful_write_read_routine_test) {
+    const std::string correct_response {"\x00\x00\x01\x1C\x00\x00\x00\x00\x00\x00\x00\x00\x00\x2d\x00\x00"
+                                        "\x00\x00\x00\x07\x00\x01\x00\x00\x00\x0b\x00\x02\x00\x00\x00\x05"
+                                        "\x00\x03\x00\x00\x00\x08\x00\x04\x00\x00\x00\x02\x00\x05\x00\x00"
+                                        "\x00\x01\x00\x06\x00\x00\x00\x05\x00\x07\x00\x00\x00\x02\x00\x08"
+                                        "\x00\x00\x00\x07\x00\x09\x00\x00\x00\x05\x00\x0a\x00\x00\x00\x02"
+                                        "\x00\x0b\x00\x00\x00\x05\x00\x0c\x00\x00\x00\x03\x00\x0d\x00\x00"
+                                        "\x00\x02\x00\x0e\x00\x00\x00\x03\x00\x0f\x00\x00\x00\x03\x00\x10"
+                                        "\x00\x00\x00\x02\x00\x11\x00\x00\x00\x01\x00\x12\x00\x00\x00\x02"
+                                        "\x00\x13\x00\x00\x00\x03\x00\x14\x00\x00\x00\x03\x00\x15\x00\x00"
+                                        "\x00\x01\x00\x16\x00\x00\x00\x01\x00\x17\x00\x00\x00\x03\x00\x18"
+                                        "\x00\x00\x00\x01\x00\x19\x00\x00\x00\x01\x00\x1a\x00\x00\x00\x01"
+                                        "\x00\x1b\x00\x00\x00\x00\x00\x1c\x00\x00\x00\x02\x00\x1d\x00\x00"
+                                        "\x00\x01\x00\x1e\x00\x00\x00\x01\x00\x1f\x00\x00\x00\x01\x00\x20"
+                                        "\x00\x00\x00\x02\x00\x21\x00\x00\x00\x01\x00\x22\x00\x00\x00\x01"
+                                        "\x00\x23\x00\x00\x00\x01\x00\x24\x00\x00\x00\x01\x00\x25\x00\x00"
+                                        "\x00\x01\x00\x26\x00\x00\x00\x01\x00\x27\x00\x00\x00\x01\x00\x28"
+                                        "\x00\x00\x00\x01\x00\x29\x00\x00\x00\x01\x00\x2a\x00\x00\x00\x01"
+                                        "\x00\x2b\x00\x00\x00\x00\x00\x2c\x00\x00\x00\x00\x00\x00\x00\x00",
+                                        18 * 16
+    };
+
+    temporary_buffer<char> message {message_str, message_len};
+
+    auto conn = kafka::tcp_connection::connect(BROKER_ADDRESS, PORT).get0();
+    conn->write(message.clone()).get();
+    auto buff = conn->read(correct_response.length()).get0();
+    std::string response {buff.get(), buff.size()};
+    BOOST_CHECK_EQUAL(response, correct_response);
+    conn->close().get();
+}


### PR DESCRIPTION
This change adds a basic, low level network connection management for the Kafka client. Later, this should be encapsulated in a TCP Client class to work on the Kafka messages abstraction.
So far the tests are also somewhat makeshift - ideally, they have to be separated into both unit and integration tests, with the former not relying on existing Kafka brokers.