### PR TITLE
Replace boost streams with own implementation.

### DIFF
--- a/src/kafka/protocol/api_versions_request.cc
+++ b/src/kafka/protocol/api_versions_request.cc
@@ -22,6 +22,6 @@
 
 #include "api_versions_request.hh"
 
-void seastar::kafka::api_versions_request::serialize(std::ostream &os, int16_t api_version) const {}
+void seastar::kafka::api_versions_request::serialize(kafka::output_stream &os, int16_t api_version) const {}
 
-void seastar::kafka::api_versions_request::deserialize(std::istream &is, int16_t api_version) {}
+void seastar::kafka::api_versions_request::deserialize(kafka::input_stream &is, int16_t api_version) {}

--- a/src/kafka/protocol/api_versions_request.hh
+++ b/src/kafka/protocol/api_versions_request.hh
@@ -22,8 +22,7 @@
 
 #pragma once
 
-#include <istream>
-#include <ostream>
+#include "streams.hh"
 
 namespace seastar {
 
@@ -31,8 +30,8 @@ namespace kafka {
 
 class api_versions_request {
 public:
-    void serialize(std::ostream &os, int16_t api_version) const;
-    void deserialize(std::istream &is, int16_t api_version);
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/api_versions_response.cc
+++ b/src/kafka/protocol/api_versions_response.cc
@@ -26,19 +26,19 @@ namespace seastar {
 
 namespace kafka {
 
-void api_versions_response_key::serialize(std::ostream &os, int16_t api_version) const {
+void api_versions_response_key::serialize(kafka::output_stream &os, int16_t api_version) const {
     _api_key.serialize(os, api_version);
     _min_version.serialize(os, api_version);
     _max_version.serialize(os, api_version);
 }
 
-void api_versions_response_key::deserialize(std::istream &is, int16_t api_version) {
+void api_versions_response_key::deserialize(kafka::input_stream &is, int16_t api_version) {
     _api_key.deserialize(is, api_version);
     _min_version.deserialize(is, api_version);
     _max_version.deserialize(is, api_version);
 }
 
-void api_versions_response::serialize(std::ostream &os, int16_t api_version) const {
+void api_versions_response::serialize(kafka::output_stream &os, int16_t api_version) const {
     _error_code.serialize(os, api_version);
     _api_keys.serialize(os, api_version);
     if (api_version >= 1) {
@@ -46,7 +46,7 @@ void api_versions_response::serialize(std::ostream &os, int16_t api_version) con
     }
 }
 
-void api_versions_response::deserialize(std::istream &is, int16_t api_version) {
+void api_versions_response::deserialize(kafka::input_stream &is, int16_t api_version) {
     _error_code.deserialize(is, api_version);
     _api_keys.deserialize(is, api_version);
     if (api_version >= 1) {

--- a/src/kafka/protocol/api_versions_response.hh
+++ b/src/kafka/protocol/api_versions_response.hh
@@ -34,9 +34,9 @@ public:
     kafka_int16_t _min_version;
     kafka_int16_t _max_version;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class api_versions_response {
@@ -45,9 +45,9 @@ public:
     kafka_array_t<api_versions_response_key> _api_keys;
     kafka_int32_t _throttle_time_ms;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/kafka_records.hh
+++ b/src/kafka/protocol/kafka_records.hh
@@ -35,9 +35,9 @@ public:
     std::string _header_key;
     std::string _value;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class kafka_record {
@@ -48,9 +48,9 @@ public:
     std::string _value;
     std::vector<kafka_record_header> _headers;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 enum class kafka_record_compression_type {
@@ -79,18 +79,18 @@ public:
 
     std::vector<kafka_record> _records;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class kafka_records {
 public:
     std::vector<kafka_record_batch> _record_batches;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/metadata_request.cc
+++ b/src/kafka/protocol/metadata_request.cc
@@ -26,15 +26,15 @@ namespace seastar {
 
 namespace kafka {
 
-void metadata_request_topic::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_request_topic::serialize(kafka::output_stream &os, int16_t api_version) const {
     _name.serialize(os, api_version);
 }
 
-void metadata_request_topic::deserialize(std::istream &is, int16_t api_version) {
+void metadata_request_topic::deserialize(kafka::input_stream &is, int16_t api_version) {
     _name.deserialize(is, api_version);
 }
 
-void metadata_request::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_request::serialize(kafka::output_stream &os, int16_t api_version) const {
     _topics.serialize(os, api_version);
     if (api_version >= 4) {
         _allow_auto_topic_creation.serialize(os, api_version);
@@ -45,7 +45,7 @@ void metadata_request::serialize(std::ostream &os, int16_t api_version) const {
     }
 }
 
-void metadata_request::deserialize(std::istream &is, int16_t api_version) {
+void metadata_request::deserialize(kafka::input_stream &is, int16_t api_version) {
     _topics.deserialize(is, api_version);
     if (api_version >= 4) {
         _allow_auto_topic_creation.deserialize(is, api_version);

--- a/src/kafka/protocol/metadata_request.hh
+++ b/src/kafka/protocol/metadata_request.hh
@@ -32,9 +32,9 @@ class metadata_request_topic {
 public:
     kafka_string_t _name;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class metadata_request {
@@ -44,9 +44,9 @@ public:
     kafka_bool_t _include_cluster_authorized_operations;
     kafka_bool_t _include_topic_authorized_operations;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/metadata_response.cc
+++ b/src/kafka/protocol/metadata_response.cc
@@ -26,7 +26,7 @@ namespace seastar {
 
 namespace kafka {
 
-void metadata_response_broker::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_response_broker::serialize(kafka::output_stream &os, int16_t api_version) const {
     _node_id.serialize(os, api_version);
     _host.serialize(os, api_version);
     _port.serialize(os, api_version);
@@ -35,7 +35,7 @@ void metadata_response_broker::serialize(std::ostream &os, int16_t api_version) 
     }
 }
 
-void metadata_response_broker::deserialize(std::istream &is, int16_t api_version) {
+void metadata_response_broker::deserialize(kafka::input_stream &is, int16_t api_version) {
     _node_id.deserialize(is, api_version);
     _host.deserialize(is, api_version);
     _port.deserialize(is, api_version);
@@ -44,7 +44,7 @@ void metadata_response_broker::deserialize(std::istream &is, int16_t api_version
     }
 }
 
-void metadata_response_partition::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_response_partition::serialize(kafka::output_stream &os, int16_t api_version) const {
     _error_code.serialize(os, api_version);
     _partition_index.serialize(os, api_version);
     _leader_id.serialize(os, api_version);
@@ -58,7 +58,7 @@ void metadata_response_partition::serialize(std::ostream &os, int16_t api_versio
     }
 }
 
-void metadata_response_partition::deserialize(std::istream &is, int16_t api_version) {
+void metadata_response_partition::deserialize(kafka::input_stream &is, int16_t api_version) {
     _error_code.deserialize(is, api_version);
     _partition_index.deserialize(is, api_version);
     _leader_id.deserialize(is, api_version);
@@ -72,7 +72,7 @@ void metadata_response_partition::deserialize(std::istream &is, int16_t api_vers
     }
 }
 
-void metadata_response_topic::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_response_topic::serialize(kafka::output_stream &os, int16_t api_version) const {
     _error_code.serialize(os, api_version);
     _name.serialize(os, api_version);
     if (api_version >= 1) {
@@ -84,7 +84,7 @@ void metadata_response_topic::serialize(std::ostream &os, int16_t api_version) c
     }
 }
 
-void metadata_response_topic::deserialize(std::istream &is, int16_t api_version) {
+void metadata_response_topic::deserialize(kafka::input_stream &is, int16_t api_version) {
     _error_code.deserialize(is, api_version);
     _name.deserialize(is, api_version);
     if (api_version >= 1) {
@@ -96,7 +96,7 @@ void metadata_response_topic::deserialize(std::istream &is, int16_t api_version)
     }
 }
 
-void metadata_response::serialize(std::ostream &os, int16_t api_version) const {
+void metadata_response::serialize(kafka::output_stream &os, int16_t api_version) const {
     if (api_version >= 3) {
         _throttle_time_ms.serialize(os, api_version);
     }
@@ -113,7 +113,7 @@ void metadata_response::serialize(std::ostream &os, int16_t api_version) const {
     }
 }
 
-void metadata_response::deserialize(std::istream &is, int16_t api_version) {
+void metadata_response::deserialize(kafka::input_stream &is, int16_t api_version) {
     if (api_version >= 3) {
         _throttle_time_ms.deserialize(is, api_version);
     }

--- a/src/kafka/protocol/metadata_response.hh
+++ b/src/kafka/protocol/metadata_response.hh
@@ -35,9 +35,9 @@ public:
     kafka_int32_t _port;
     kafka_nullable_string_t _rack;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class metadata_response_partition {
@@ -50,9 +50,9 @@ public:
     kafka_array_t<kafka_int32_t> _isr_nodes;
     kafka_array_t<kafka_int32_t> _offline_replicas;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class metadata_response_topic {
@@ -63,9 +63,9 @@ public:
     kafka_array_t<metadata_response_partition> _partitions;
     kafka_int32_t _topic_authorized_operations;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class metadata_response {
@@ -77,9 +77,9 @@ public:
     kafka_array_t<metadata_response_topic> _topics;
     kafka_int32_t _cluster_authorized_operations;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/produce_request.cc
+++ b/src/kafka/protocol/produce_request.cc
@@ -26,27 +26,27 @@ namespace seastar {
 
 namespace kafka {
 
-void produce_request_partition_produce_data::serialize(std::ostream &os, int16_t api_version) const {
+void produce_request_partition_produce_data::serialize(kafka::output_stream &os, int16_t api_version) const {
     _partition_index.serialize(os, api_version);
     _records.serialize(os, api_version);
 }
 
-void produce_request_partition_produce_data::deserialize(std::istream &is, int16_t api_version) {
+void produce_request_partition_produce_data::deserialize(kafka::input_stream &is, int16_t api_version) {
     _partition_index.deserialize(is, api_version);
     _records.deserialize(is, api_version);
 }
 
-void produce_request_topic_produce_data::serialize(std::ostream &os, int16_t api_version) const {
+void produce_request_topic_produce_data::serialize(kafka::output_stream &os, int16_t api_version) const {
     _name.serialize(os, api_version);
     _partitions.serialize(os, api_version);
 }
 
-void produce_request_topic_produce_data::deserialize(std::istream &is, int16_t api_version) {
+void produce_request_topic_produce_data::deserialize(kafka::input_stream &is, int16_t api_version) {
     _name.deserialize(is, api_version);
     _partitions.deserialize(is, api_version);
 }
 
-void produce_request::serialize(std::ostream &os, int16_t api_version) const {
+void produce_request::serialize(kafka::output_stream &os, int16_t api_version) const {
     if (api_version >= 3) {
         _transactional_id.serialize(os, api_version);
     }
@@ -55,7 +55,7 @@ void produce_request::serialize(std::ostream &os, int16_t api_version) const {
     _topics.serialize(os, api_version);
 }
 
-void produce_request::deserialize(std::istream &is, int16_t api_version) {
+void produce_request::deserialize(kafka::input_stream &is, int16_t api_version) {
     if (api_version >= 3) {
         _transactional_id.deserialize(is, api_version);
     }

--- a/src/kafka/protocol/produce_request.hh
+++ b/src/kafka/protocol/produce_request.hh
@@ -34,9 +34,9 @@ public:
     kafka_int32_t _partition_index;
     kafka_records _records;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class produce_request_topic_produce_data {
@@ -44,9 +44,9 @@ public:
     kafka_string_t _name;
     kafka_array_t<produce_request_partition_produce_data> _partitions;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class produce_request {
@@ -56,9 +56,9 @@ public:
     kafka_int32_t _timeout_ms;
     kafka_array_t<produce_request_topic_produce_data> _topics;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/produce_response.cc
+++ b/src/kafka/protocol/produce_response.cc
@@ -26,17 +26,17 @@ namespace seastar {
 
 namespace kafka {
 
-void produce_response_batch_index_and_error_message::serialize(std::ostream &os, int16_t api_version) const {
+void produce_response_batch_index_and_error_message::serialize(kafka::output_stream &os, int16_t api_version) const {
     _batch_index.serialize(os, api_version);
     _batch_index_error_message.serialize(os, api_version);
 }
 
-void produce_response_batch_index_and_error_message::deserialize(std::istream &is, int16_t api_version) {
+void produce_response_batch_index_and_error_message::deserialize(kafka::input_stream &is, int16_t api_version) {
     _batch_index.deserialize(is, api_version);
     _batch_index_error_message.deserialize(is, api_version);
 }
 
-void produce_response_partition_produce_response::serialize(std::ostream &os, int16_t api_version) const {
+void produce_response_partition_produce_response::serialize(kafka::output_stream &os, int16_t api_version) const {
     _partition_index.serialize(os, api_version);
     _error_code.serialize(os, api_version);
     _base_offset.serialize(os, api_version);
@@ -52,7 +52,7 @@ void produce_response_partition_produce_response::serialize(std::ostream &os, in
     }
 }
 
-void produce_response_partition_produce_response::deserialize(std::istream &is, int16_t api_version) {
+void produce_response_partition_produce_response::deserialize(kafka::input_stream &is, int16_t api_version) {
     _partition_index.deserialize(is, api_version);
     _error_code.deserialize(is, api_version);
     _base_offset.deserialize(is, api_version);
@@ -68,24 +68,24 @@ void produce_response_partition_produce_response::deserialize(std::istream &is, 
     }
 }
 
-void produce_response_topic_produce_response::serialize(std::ostream &os, int16_t api_version) const {
+void produce_response_topic_produce_response::serialize(kafka::output_stream &os, int16_t api_version) const {
     _name.serialize(os, api_version);
     _partitions.serialize(os, api_version);
 }
 
-void produce_response_topic_produce_response::deserialize(std::istream &is, int16_t api_version) {
+void produce_response_topic_produce_response::deserialize(kafka::input_stream &is, int16_t api_version) {
     _name.deserialize(is, api_version);
     _partitions.deserialize(is, api_version);
 }
 
-void produce_response::serialize(std::ostream &os, int16_t api_version) const {
+void produce_response::serialize(kafka::output_stream &os, int16_t api_version) const {
     _responses.serialize(os, api_version);
     if (api_version >= 1) {
         _throttle_time_ms.serialize(os, api_version);
     }
 }
 
-void produce_response::deserialize(std::istream &is, int16_t api_version) {
+void produce_response::deserialize(kafka::input_stream &is, int16_t api_version) {
     _responses.deserialize(is, api_version);
     if (api_version >= 1) {
         _throttle_time_ms.deserialize(is, api_version);

--- a/src/kafka/protocol/produce_response.hh
+++ b/src/kafka/protocol/produce_response.hh
@@ -37,9 +37,9 @@ public:
 
     [[nodiscard]] const kafka_nullable_string_t &get_batch_index_error_message() const;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class produce_response_partition_produce_response {
@@ -52,9 +52,9 @@ public:
     kafka_array_t<produce_response_batch_index_and_error_message> _record_errors;
     kafka_nullable_string_t _error_message;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class produce_response_topic_produce_response {
@@ -62,9 +62,9 @@ public:
     kafka_string_t _name;
     kafka_array_t<produce_response_partition_produce_response> _partitions;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 class produce_response {
@@ -72,9 +72,9 @@ public:
     kafka_array_t<produce_response_topic_produce_response> _responses;
     kafka_int32_t _throttle_time_ms;
 
-    void serialize(std::ostream &os, int16_t api_version) const;
+    void serialize(kafka::output_stream &os, int16_t api_version) const;
 
-    void deserialize(std::istream &is, int16_t api_version);
+    void deserialize(kafka::input_stream &is, int16_t api_version);
 };
 
 }

--- a/src/kafka/protocol/streams.hh
+++ b/src/kafka/protocol/streams.hh
@@ -1,0 +1,173 @@
+#ifndef __STREAMS_HH__
+#define __STREAMS_HH__
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+using std::vector;
+
+namespace seastar {
+    namespace kafka {
+
+    struct parsing_exception : public std::runtime_error {
+    public:
+        parsing_exception(const std::string& message) : runtime_error(message) {}
+    };
+
+    class input_stream {
+    private:
+        const char *_data;
+        int32_t _length;
+        int32_t _current_position = 0;
+        int32_t _gcount = 0;
+
+    public:
+        input_stream(const char *data, int32_t length) noexcept
+            : _data(data)
+            , _length(length)
+        {}
+
+        inline void read(char *destination, int32_t length) {
+            if(_current_position + length > _length){
+                throw kafka::parsing_exception ("Attempted to read more than the remaining length of the input stream.");
+            }
+            std::copy((_data + _current_position), (_data + _current_position + length), destination);
+            _current_position += length;
+            _gcount = length;
+        }
+
+        inline int32_t gcount() const {
+            return _gcount;
+        }
+
+        inline const char *get() const {
+            if(_current_position == _length) {
+                throw kafka::parsing_exception("Input stream is exhausted.");
+            }
+            return _data + _current_position;
+        }
+
+        inline int32_t get_position() const noexcept {
+            return _current_position;
+        }
+
+        inline void set_position(int32_t new_position) {
+            if(new_position >= _length || new_position < 0) {
+                throw kafka::parsing_exception("Attempted to set input stream's position outside its data.");
+            }
+            else {
+                _current_position = new_position;
+            }
+        }
+
+        inline void move_position(int32_t delta) {
+            set_position(_current_position + delta);
+        }
+        
+        int32_t size() const noexcept {
+            return _length;
+        }
+
+        inline const char * begin() const {
+            return _data;
+        }
+    };
+
+    class output_stream {
+    private:
+        vector<char> _data;
+
+        int32_t _current_position = 0;
+        bool _is_resizable;
+
+        output_stream(bool is_resizable, int32_t size) noexcept
+                : _data(vector<char>(size, 0))
+                , _is_resizable(is_resizable)
+        {}
+
+    public:
+
+        static output_stream fixed_size_stream(int32_t size) {
+            return output_stream(false, size);
+        }
+
+        static output_stream resizable_stream() {
+            return output_stream(true, 0);
+        }
+
+        inline void write(const char *source, int32_t length) {
+            if(length + _current_position > static_cast<int32_t>(_data.size())) {
+                if(_is_resizable){
+                    _data.resize(length + _current_position);
+                }
+                else {
+                    throw kafka::parsing_exception("This output stream won't fit that many bytes.");
+                }
+            }
+            std::copy(source, source + length, _data.data() + _current_position);
+            _current_position += length;
+        }
+
+        inline char *get() {
+            if(_current_position == static_cast<int32_t>(_data.size())) {
+                throw kafka::parsing_exception("Output stream is full.");
+            }
+            return _data.data() + _current_position;
+        }
+
+        inline const char *get() const {
+            if(_current_position == static_cast<int32_t>(_data.size())) {
+                throw kafka::parsing_exception("Output stream is full.");
+            }
+            return _data.data() + _current_position;
+        }
+
+        inline const char * begin() const {
+            return _data.data();
+        }
+
+        inline vector<char> &get_vector() noexcept {
+            return _data;
+        }
+
+        inline const vector<char> &get_vector() const noexcept {
+            return _data;
+        }
+
+        inline int32_t get_position() const noexcept {
+            return _current_position;
+        }
+
+        inline void set_position(int32_t new_position) {
+            if(new_position < 0) {
+                throw kafka::parsing_exception("Cannot set position to negative value.");
+            }
+
+            if(_is_resizable) {
+                _data.resize(new_position + 1);
+            }
+            else {
+                if(new_position >= static_cast<int32_t>(_data.size())) {
+                    kafka::parsing_exception("Attempted to set fixed output stream's position past its data.");
+                }
+            }
+
+            _current_position = new_position;
+        }
+
+        inline void move_position(int32_t delta) {
+            set_position(_current_position + delta);
+        }
+
+        int32_t size() const noexcept {
+            return _data.size();
+        }
+    };
+
+} // namespace kafka
+
+} // namespace seastar
+
+#endif // __STREAMS_HH__


### PR DESCRIPTION
Replaces boost iostreams with simple streams made from scratch.
Updates kafka_protocol_test by replacing streams and fixing minor problem with signed/unsigned chars.