### PR TITLE
fs: tests: block_device: fixed stalling warnings + little refactor

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -352,8 +352,8 @@ if (Seastar_EXPERIMENTAL_FS)
   seastar_add_test (cluster_allocator
     KIND BOOST
     SOURCES cluster_allocator_test.cc)
-  seastar_add_app_test (block_device
-    SOURCES block_device_test.cc
+  seastar_add_app_test (fs_block_device
+    SOURCES fs_block_device_test.cc
     LIBRARIES seastar_testing)
   seastar_add_test (fs_bootstrap_record
     SOURCES fs_bootstrap_record_test.cc)


### PR DESCRIPTION
- allocate_random_aligned_buffer() was not asynchronous and called with a big
  argument like 2^24 it stalled the reactor for a couple hundred milliseconds.
- changed memcmp() to std::memcmp()
- changed sstring to std::string
- added prefix "fs_" to test name