### PR TITLE
fs: compaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -686,6 +686,7 @@ if (Seastar_EXPERIMENTAL_FS)
     src/fs/backend/cluster_writer.hh
     src/fs/backend/create_and_open_unlinked_file.hh
     src/fs/backend/create_file.hh
+    src/fs/backend/data_cluster_contents_info.hh
     src/fs/backend/inode_info.hh
     src/fs/backend/link_file.hh
     src/fs/backend/metadata_log/entries.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,8 @@ if (Seastar_EXPERIMENTAL_FS)
     src/fs/backend/create_and_open_unlinked_file.hh
     src/fs/backend/create_file.hh
     src/fs/backend/data_cluster_contents_info.hh
+    src/fs/backend/data_compaction.cc
+    src/fs/backend/data_compaction.hh
     src/fs/backend/inode_info.hh
     src/fs/backend/link_file.hh
     src/fs/backend/metadata_log/entries.cc

--- a/include/seastar/fs/exceptions.hh
+++ b/include/seastar/fs/exceptions.hh
@@ -89,6 +89,10 @@ struct filesystem_has_not_been_invalidated_exception : public fs_exception {
     const char* what() const noexcept override { return "File system has not been invalidated"; }
 };
 
+struct read_only_filesystem_exception : public fs_exception {
+    const char* what() const noexcept override { return "Read only file system"; }
+};
+
 struct path_lookup_exception : public fs_exception {
     const char* what() const noexcept override = 0;
 };

--- a/include/seastar/fs/exceptions.hh
+++ b/include/seastar/fs/exceptions.hh
@@ -93,6 +93,10 @@ struct read_only_filesystem_exception : public fs_exception {
     const char* what() const noexcept override { return "Read only file system"; }
 };
 
+struct input_output_exception : public fs_exception {
+    const char* what() const noexcept override { return "Input/output error"; }
+};
+
 struct path_lookup_exception : public fs_exception {
     const char* what() const noexcept override = 0;
 };

--- a/include/seastar/fs/filesystem.hh
+++ b/include/seastar/fs/filesystem.hh
@@ -49,7 +49,8 @@ public:
     filesystem& operator=(const filesystem&) = delete;
     filesystem(filesystem&&) = default;
 
-    future<> start(std::string device_path, foreign_ptr<lw_shared_ptr<global_shared_root>> root);
+    future<> start(std::string device_path, foreign_ptr<lw_shared_ptr<global_shared_root>> root, double compactness,
+        size_t max_data_compaction_memory);
 
     future<shared_entries> local_root();
 
@@ -81,7 +82,7 @@ private:
     future<stub_file_handle> create_and_open_inode(std::string path);
 };
 
-future<> bootfs(sharded<filesystem>& fs, std::string device_path);
+future<> bootfs(sharded<filesystem>& fs, std::string device_path, double compactness, size_t max_data_compaction_memory);
 
 future<> mkfs(std::string device_path, uint64_t version, disk_offset_t cluster_size, disk_offset_t alignment,
         inode_t root_directory, uint32_t shards_nb);

--- a/src/fs/backend/bootstrapping.cc
+++ b/src/fs/backend/bootstrapping.cc
@@ -74,6 +74,7 @@ future<> bootstrapping::bootstrap(cluster_id_t first_metadata_cluster_id, fs_sha
         fs_shard_id_t fs_shard_id) {
     _next_cluster = first_metadata_cluster_id;
     mlogger.debug(">>>>  Started bootstrapping  <<<<");
+    // TODO: disable all compaction during bootstrapping -- it cannot happen now because we just replay the metadata log
     return do_until([this] { return !_next_cluster; }, [this] {
         _curr_cluster.id = *_next_cluster;
         _next_cluster = std::nullopt;

--- a/src/fs/backend/cluster_allocator.cc
+++ b/src/fs/backend/cluster_allocator.cc
@@ -20,6 +20,7 @@
  */
 
 #include "fs/backend/cluster_allocator.hh"
+#include "seastar/core/semaphore.hh"
 #include "seastar/util/log.hh"
 
 #include <cassert>
@@ -90,10 +91,10 @@ std::optional<cluster_id_t> cluster_allocator::alloc() noexcept {
     return cluster_id;
 }
 
-future<std::vector<cluster_id_t>> cluster_allocator::alloc_wait(size_t count) {
+future<std::vector<cluster_id_t>> cluster_allocator::alloc_wait(semaphore::duration duration, size_t count) {
     std::vector<cluster_id_t> cluster_ids;
     cluster_ids.reserve(count);
-    return _cluster_sem.wait(count).then([this, count, cluster_ids = std::move(cluster_ids)]() mutable {
+    return _cluster_sem.wait(duration, count).then([this, count, cluster_ids = std::move(cluster_ids)]() mutable {
         for (size_t i = 0; i < count; ++i) {
             cluster_ids.emplace_back(do_alloc());
         }

--- a/src/fs/backend/cluster_allocator.cc
+++ b/src/fs/backend/cluster_allocator.cc
@@ -20,8 +20,14 @@
  */
 
 #include "fs/backend/cluster_allocator.hh"
+#include "seastar/util/log.hh"
 
 #include <cassert>
+
+
+namespace {
+seastar::logger mlogger("fs_backend_cluster_allocator");
+} // namespace
 
 namespace seastar::fs::backend {
 
@@ -79,7 +85,9 @@ std::optional<cluster_id_t> cluster_allocator::alloc() noexcept {
 
     assert(_free_clusters.size() > 0);
 
-    return do_alloc();
+    cluster_id_t cluster_id = do_alloc();
+    mlogger.debug("Allocating cluster: {}", cluster_id);
+    return cluster_id;
 }
 
 future<std::vector<cluster_id_t>> cluster_allocator::alloc_wait(size_t count) {
@@ -89,16 +97,19 @@ future<std::vector<cluster_id_t>> cluster_allocator::alloc_wait(size_t count) {
         for (size_t i = 0; i < count; ++i) {
             cluster_ids.emplace_back(do_alloc());
         }
+        mlogger.debug("Allocating clusters: {}", cluster_ids);
         return make_ready_future<std::vector<cluster_id_t>>(std::move(cluster_ids));
     });
 }
 
 void cluster_allocator::free(cluster_id_t cluster_id) noexcept {
+    mlogger.debug("Freeing cluster: {}", cluster_id);
     do_free(cluster_id);
     _cluster_sem.signal();
 }
 
 void cluster_allocator::free(const std::vector<cluster_id_t>& cluster_ids) noexcept {
+    mlogger.debug("Freeing clusters: {}", cluster_ids);
     for (auto& cluster_id : cluster_ids) {
         do_free(cluster_id);
     }

--- a/src/fs/backend/cluster_allocator.cc
+++ b/src/fs/backend/cluster_allocator.cc
@@ -16,35 +16,93 @@
  * under the License.
  */
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2020 ScyllaDB
  */
 
 #include "fs/backend/cluster_allocator.hh"
-#include "seastar/fs/unit_types.hh"
 
 #include <cassert>
-#include <optional>
 
 namespace seastar::fs::backend {
 
-cluster_allocator::cluster_allocator(std::unordered_set<cluster_id_t> allocated_clusters, std::deque<cluster_id_t> free_clusters)
-        : _allocated_clusters(std::move(allocated_clusters)), _free_clusters(std::move(free_clusters)) {}
+cluster_allocator::cluster_allocator() : _cluster_sem(0) {}
 
-std::optional<cluster_id_t> cluster_allocator::alloc() {
-    if (_free_clusters.empty()) {
-        return std::nullopt;
-    }
+cluster_allocator::cluster_allocator(std::unordered_set<cluster_id_t> allocated_clusters,
+        circular_buffer<cluster_id_t> free_clusters)
+        : cluster_allocator() {
+    reset(std::move(allocated_clusters), std::move(free_clusters));
+}
+
+void cluster_allocator::reset(std::unordered_set<cluster_id_t> allocated_clusters,
+        circular_buffer<cluster_id_t> free_clusters) {
+    assert((size_t)_cluster_sem.available_units() == _free_clusters.size());
+    assert(_cluster_sem.waiters() == 0);
+
+    free_clusters.reserve(free_clusters.size() + allocated_clusters.size());
+    _allocated_clusters = [&] {
+        std::unordered_map<cluster_id_t, bool> allocated_clusters_tmp;
+        for (auto& i : allocated_clusters) {
+            allocated_clusters_tmp.emplace(i, true);
+        }
+        for (auto& i : free_clusters) {
+            allocated_clusters_tmp.emplace(i, false);
+        }
+        return allocated_clusters_tmp;
+    }();
+    _free_clusters = std::move(free_clusters);
+
+    _cluster_sem.consume(_cluster_sem.available_units());
+    _cluster_sem.signal(_free_clusters.size());
+}
+
+cluster_id_t cluster_allocator::do_alloc() noexcept {
+    assert(!_free_clusters.empty());
 
     cluster_id_t cluster_id = _free_clusters.front();
     _free_clusters.pop_front();
-    _allocated_clusters.insert(cluster_id);
+    _allocated_clusters[cluster_id] = true;
+
     return cluster_id;
 }
 
-void cluster_allocator::free(cluster_id_t cluster_id) {
+void cluster_allocator::do_free(cluster_id_t cluster_id) noexcept {
     assert(_allocated_clusters.count(cluster_id) == 1);
     _free_clusters.emplace_back(cluster_id);
-    _allocated_clusters.erase(cluster_id);
+    _allocated_clusters[cluster_id] = false;
+}
+
+std::optional<cluster_id_t> cluster_allocator::alloc() noexcept {
+    if (_cluster_sem.available_units() == 0) {
+        return std::nullopt;
+    }
+    _cluster_sem.consume(1);
+
+    assert(_free_clusters.size() > 0);
+
+    return do_alloc();
+}
+
+future<std::vector<cluster_id_t>> cluster_allocator::alloc_wait(size_t count) {
+    std::vector<cluster_id_t> cluster_ids;
+    cluster_ids.reserve(count);
+    return _cluster_sem.wait(count).then([this, count, cluster_ids = std::move(cluster_ids)]() mutable {
+        for (size_t i = 0; i < count; ++i) {
+            cluster_ids.emplace_back(do_alloc());
+        }
+        return make_ready_future<std::vector<cluster_id_t>>(std::move(cluster_ids));
+    });
+}
+
+void cluster_allocator::free(cluster_id_t cluster_id) noexcept {
+    do_free(cluster_id);
+    _cluster_sem.signal();
+}
+
+void cluster_allocator::free(const std::vector<cluster_id_t>& cluster_ids) noexcept {
+    for (auto& cluster_id : cluster_ids) {
+        do_free(cluster_id);
+    }
+    _cluster_sem.signal(cluster_ids.size());
 }
 
 } // namespace seastar::fs::backend

--- a/src/fs/backend/cluster_allocator.hh
+++ b/src/fs/backend/cluster_allocator.hh
@@ -16,32 +16,59 @@
  * under the License.
  */
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2020 ScyllaDB
  */
 
 #pragma once
 
+#include "seastar/core/circular_buffer.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/semaphore.hh"
 #include "seastar/fs/unit_types.hh"
 
-#include <deque>
+#include <cstdint>
 #include <optional>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 namespace seastar::fs::backend {
 
 class cluster_allocator {
     // TODO: maybe optimize it using bitset?
-    std::unordered_set<cluster_id_t> _allocated_clusters;
-    std::deque<cluster_id_t> _free_clusters;
+    std::unordered_map<cluster_id_t, bool> _allocated_clusters;
+    circular_buffer<cluster_id_t> _free_clusters;
+    semaphore _cluster_sem;
+
+    cluster_id_t do_alloc() noexcept;
+    void do_free(cluster_id_t cluster_id) noexcept;
 
 public:
-    explicit cluster_allocator(std::unordered_set<cluster_id_t> allocated_clusters, std::deque<cluster_id_t> free_clusters);
+    cluster_allocator();
+    cluster_allocator(std::unordered_set<cluster_id_t> allocated_clusters, circular_buffer<cluster_id_t> free_clusters);
 
-    // Tries to allocate a cluster
-    std::optional<cluster_id_t> alloc();
+    cluster_allocator(const cluster_allocator&) = delete;
+    cluster_allocator& operator=(const cluster_allocator&) = delete;
+    cluster_allocator(cluster_allocator&&) = default;
+    cluster_allocator& operator=(cluster_allocator&&) = delete;
 
-    // @p cluster_id has to be allocated using alloc()
-    void free(cluster_id_t cluster_id);
+    // Changes cluster_allocator's set of free and allocated clusters. Assumes that there are no allocated clusters
+    // and nobody uses the cluster_allocator (e.g. waiting to alloc() a cluster).
+    // Strong exception guarantee is provided.
+    void reset(std::unordered_set<cluster_id_t> allocated_clusters, circular_buffer<cluster_id_t> free_clusters);
+
+    // Tries to allocate a cluster.
+    std::optional<cluster_id_t> alloc() noexcept;
+
+    // Waits until @p count free clusters are available and allocates them.
+    // Strong exception guarantee is provided.
+    future<std::vector<cluster_id_t>> alloc_wait(size_t count = 1);
+
+    // @p cluster_id has to be allocated using alloc() or alloc_wait()
+    void free(cluster_id_t cluster_id) noexcept;
+
+    // @p cluster_ids have to be allocated using alloc() or alloc_wait()
+    void free(const std::vector<cluster_id_t>& cluster_ids) noexcept;
 
     size_t remaining_clusters_number() const noexcept {
         return _free_clusters.size();

--- a/src/fs/backend/cluster_allocator.hh
+++ b/src/fs/backend/cluster_allocator.hh
@@ -62,7 +62,7 @@ public:
 
     // Waits until @p count free clusters are available and allocates them.
     // Strong exception guarantee is provided.
-    future<std::vector<cluster_id_t>> alloc_wait(size_t count = 1);
+    future<std::vector<cluster_id_t>> alloc_wait(semaphore::duration duration, size_t count = 1);
 
     // @p cluster_id has to be allocated using alloc() or alloc_wait()
     void free(cluster_id_t cluster_id) noexcept;

--- a/src/fs/backend/cluster_writer.hh
+++ b/src/fs/backend/cluster_writer.hh
@@ -39,6 +39,7 @@ protected:
     disk_offset_t _alignment = 0;
     disk_offset_t _cluster_beg_offset = 0;
     size_t _next_write_offset = 0;
+    size_t _use_cnt = 0;
 public:
     cluster_writer() = default;
 
@@ -79,6 +80,18 @@ public:
     // TODO: maybe better name for that function? Or any other method to extract that data?
     virtual disk_offset_t current_disk_offset() const noexcept {
         return _cluster_beg_offset + _next_write_offset;
+    }
+
+    disk_offset_t initial_disk_offset() const noexcept {
+        return _cluster_beg_offset;
+    }
+
+    void change_use_counter(ssize_t num) noexcept {
+        _use_cnt += num;
+    }
+
+    ssize_t get_use_counter() const noexcept {
+        return _use_cnt;
     }
 };
 

--- a/src/fs/backend/data_cluster_contents_info.hh
+++ b/src/fs/backend/data_cluster_contents_info.hh
@@ -51,6 +51,10 @@ public:
         return _up_to_date_data_size == 0;
     }
 
+    size_t get_up_to_date_data_size() const noexcept {
+        return _up_to_date_data_size;
+    }
+
     void read_lock_nowait() {
         bool locked = _lock.try_read_lock();
         assert(locked);

--- a/src/fs/backend/data_cluster_contents_info.hh
+++ b/src/fs/backend/data_cluster_contents_info.hh
@@ -1,0 +1,81 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+#pragma once
+
+#include "fs/backend/inode_info.hh"
+#include "seastar/fs/unit_types.hh"
+
+#include <map>
+
+namespace seastar::fs::backend {
+
+class data_cluster_contents_info {
+public:
+    // Each cluster_data_vec corresponds to an inode_data_vec
+    struct cluster_data_vec {
+        inode_t data_owner;
+        file_range data_range;
+    };
+
+private:
+    size_t _up_to_date_data_size = 0;
+    std::map<disk_offset_t, cluster_data_vec> _data;
+
+public:
+    const std::map<disk_offset_t, cluster_data_vec>& get_data() const noexcept {
+        return _data;
+    }
+
+    bool is_empty() const noexcept {
+        return _up_to_date_data_size == 0;
+    }
+
+    void add_data(disk_offset_t disk_offset, inode_t inode, file_range data_range) noexcept {
+        auto [it, inserted] = _data.emplace(disk_offset, cluster_data_vec {inode, data_range});
+        assert(inserted);
+        _up_to_date_data_size += data_range.size();
+        auto pv = std::prev(it);
+        assert(it == _data.begin() || disk_offset >= pv->first + pv->second.data_range.size());
+        auto nx = std::next(it);
+        assert(nx == _data.end() || nx->first >= disk_offset + data_range.size());
+    }
+
+    void cut_data(disk_offset_t disk_offset, file_range former_range, file_range new_left_range, file_range new_right_range) {
+        auto data_vec_nh = _data.extract(disk_offset);
+        assert(!data_vec_nh.empty());
+        assert(data_vec_nh.mapped().data_range == former_range);
+        assert(former_range.beg == new_left_range.beg && former_range.end == new_right_range.end);
+        assert(new_left_range.end <= new_right_range.beg);
+        assert(new_left_range.size() >= 0 && new_right_range.size() >= 0);
+        auto inode = data_vec_nh.mapped().data_owner;
+        if (!new_left_range.is_empty()) {
+            data_vec_nh.mapped() = {inode, new_left_range};
+            _data.insert(std::move(data_vec_nh));
+        }
+        if (!new_right_range.is_empty()) {
+            _data.emplace(disk_offset + former_range.size() - new_right_range.size(), cluster_data_vec {inode, new_right_range});
+        }
+        _up_to_date_data_size -= former_range.size() - new_left_range.size() - new_right_range.size();
+    }
+};
+
+} // namespace seastar::fs::backend

--- a/src/fs/backend/data_compaction.cc
+++ b/src/fs/backend/data_compaction.cc
@@ -27,12 +27,14 @@
 #include "seastar/core/do_with.hh"
 #include "seastar/core/future-util.hh"
 #include "seastar/core/future.hh"
+#include "seastar/core/semaphore.hh"
 #include "seastar/core/temporary_buffer.hh"
 #include "seastar/fs/bitwise.hh"
 #include "seastar/fs/unit_types.hh"
 
 #include <algorithm>
 #include <boost/iterator/counting_iterator.hpp>
+#include <chrono>
 #include <exception>
 #include <optional>
 #include <stdexcept>
@@ -214,8 +216,9 @@ future<> data_compaction::allocate_clusters(std::vector<std::vector<compacted_da
     // Now allocate needed clusters and update offsets adding cluster beginning offset
     // TODO: we could first try to allocate clusters from shared cluster_allocater and if it fails wait for clusters
     //       from another (destined only for compactions) cluster_allocator
-    mlogger.debug("trying to allocate {} clusters", grouped_data_vecs.size());
-    return _shard._cluster_allocator.alloc_wait(grouped_data_vecs.size()).then(
+    size_t alloc_size = grouped_data_vecs.size();
+    mlogger.debug("trying to allocate {} clusters", alloc_size);
+    return _shard._cluster_allocator.alloc_wait(semaphore::duration(std::chrono::seconds(3)), alloc_size).then(
             [this, grouped_data_vecs = std::move(grouped_data_vecs), memory_data_vecs = std::move(memory_data_vecs)]
             (std::vector<cluster_id_t> cluster_ids) mutable {
         mlogger.debug("destination clusters: {} for compacted clusters {}", cluster_ids, _compacted_cluster_ids);
@@ -227,6 +230,9 @@ future<> data_compaction::allocate_clusters(std::vector<std::vector<compacted_da
         }
 
         return save_compacted_data_vecs(std::move(cluster_ids), std::move(grouped_data_vecs), std::move(memory_data_vecs));
+    }).handle_exception_type([alloc_size = alloc_size](seastar::semaphore_timed_out e) {
+        mlogger.warn("Couldn't allocate {} clusters for compaction. Aborting compaction.", alloc_size);
+        return make_exception_future(seastar::fs::no_more_space_exception());
     });
 }
 

--- a/src/fs/backend/data_compaction.cc
+++ b/src/fs/backend/data_compaction.cc
@@ -1,0 +1,417 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+#include "fs/backend/data_compaction.hh"
+#include "fs/backend/inode_info.hh"
+#include "fs/backend/metadata_log/entries.hh"
+#include "fs/backend/write.hh"
+#include "fs/device_reader.hh"
+#include "seastar/core/do_with.hh"
+#include "seastar/core/future-util.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/temporary_buffer.hh"
+#include "seastar/fs/bitwise.hh"
+#include "seastar/fs/unit_types.hh"
+
+#include <algorithm>
+#include <boost/iterator/counting_iterator.hpp>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <variant>
+
+namespace {
+seastar::logger mlogger("fs_backend_data_compaction");
+} // namespace
+
+namespace seastar::fs::backend {
+
+future<> data_compaction::compact() {
+    mlogger.debug(">>>>  Started compaction  <<<<");
+    mlogger.debug("source clusters: {}", _compacted_cluster_ids);
+
+    auto allocate_compacted_data_vec = [&](disk_offset_t disk_offset,
+            const data_cluster_contents_info::cluster_data_vec& data) {
+        compacted_data_vec vec {
+            ._data = temporary_buffer<uint8_t>::aligned(_shard._alignment,
+                    round_up_to_multiple_of_power_of_2(data.data_range.size(), _shard._alignment)),
+            ._inode_id = data.data_owner,
+            ._file_offset = data.data_range.beg,
+            ._prev_disk_offset = disk_offset,
+            ._post_disk_offset = std::nullopt
+        };
+        vec._data.trim(data.data_range.size());
+        return vec;
+    };
+    std::sort(_compacted_cluster_ids.begin(), _compacted_cluster_ids.end()); // TODO: verify if this is needed here or
+                                                                             //       is it already done by caller
+    std::vector<compacted_data_vec> data_vecs;
+    for (auto& cluster_id : _compacted_cluster_ids) {
+        auto cluster_it = _shard._writable_data_clusters.find(cluster_id);
+        assert(cluster_it != _shard._writable_data_clusters.end()
+            && "invalid cluster id, cluster doesn't store data or cluster isn't marked for compaction");
+        for (auto& [disk_offset, data] : cluster_it->second.get_data()) {
+            data_vecs.emplace_back(allocate_compacted_data_vec(disk_offset, data));
+        }
+    }
+
+    // It is quite common to call compaction with empty clusters to immediately free those clusters
+    auto compact_future = data_vecs.empty() ? now() : read_data_vectors(std::move(data_vecs));
+
+    return compact_future.finally([this] {
+        auto metadata_log_flush = _was_metadata_log_modified ? _shard.flush_log() : now();
+        return metadata_log_flush.then([this] {
+            return parallel_for_each(_compacted_cluster_ids, [this](cluster_id_t cluster_id) {
+                auto cluster_it = _shard._writable_data_clusters.find(cluster_id);
+                assert(cluster_it != _shard._writable_data_clusters.end());
+                if (cluster_it->second.is_empty()) {
+                    return cluster_it->second.wait_for_all_readers_to_unlock().then(
+                            [this, cluster_id, cluster_it = std::move(cluster_it)] {
+                        // TODO: throw if read_only or allow it here?
+                        mlogger.debug("releasing cluster: {}", cluster_id);
+                        _shard.free_writable_data_cluster(cluster_id);
+                    });
+                } else {
+                    mlogger.warn("cluster {} not empty after compaction - cannot free", cluster_id);
+                    _shard.finish_writing_data_cluster(cluster_id);
+                    return now();
+                }
+            });
+        }).handle_exception([this](std::exception_ptr ptr) {
+            for (auto& cluster_id : _compacted_cluster_ids) {
+                _shard.finish_writing_data_cluster(cluster_id);
+            }
+            mlogger.warn("Exception while flushing log after compaction: cannot free compacted clusters.");
+            return make_exception_future(std::move(ptr));
+        });
+    });
+}
+
+future<> data_compaction::read_data_vectors(std::vector<compacted_data_vec> data_vecs) {
+    // TODO: We could read the whole cluster when we read more data from it than some threshold (for example
+    //       more than 40%).
+    return do_with(device_reader(_shard._device, _shard._alignment), std::move(data_vecs),
+            [this](device_reader& reader, std::vector<compacted_data_vec>& data_vecs) {
+        return do_for_each(data_vecs, [&reader](compacted_data_vec& vec) {
+            return reader.read(vec._data.get_write(), vec._prev_disk_offset, vec._data.size()).then(
+                    [expected_read_len = vec._data.size()](size_t read_len) {
+                if (read_len != expected_read_len) {
+                    return make_exception_future<>(input_output_exception());
+                }
+                return now();
+            });
+        }).then([this, &data_vecs] {
+            return group_data_into_clusters(std::move(data_vecs));
+        });
+    });
+}
+
+future<> data_compaction::group_data_into_clusters(std::vector<compacted_data_vec> read_data_vecs) {
+    _shard.throw_if_read_only_fs();
+
+    // TODO: we could group data vecs by file and merge them to perform some defragmentation
+
+    // First divide data into clusters and calculate data offsets in new clusters
+    std::vector<std::vector<compacted_data_vec>> grouped_data_vecs;
+    std::vector<compacted_data_vec> memory_data_vecs;
+    {
+        // TODO: We could try to avoid splitting the data using smarter strategies. That problem is similar to the multiple
+        // knapsack problem where knapsacks are clusters and items are data vectors. In that case we would need
+        // to remember that the main purpose of the compaction isn't smart placement of data vectors and defragmentation
+        // but releasing clusters.
+        bool should_add_new_group = true;
+        size_t in_cluster_offset = 0;
+        // For now calculate offsets of new data vecs in clusters. We will calculate final on-disk offsets after
+        // clusters allocation.
+        for (auto& file_data_vec : read_data_vecs) {
+            size_t remaining_data_size = file_data_vec._data.size();
+            size_t data_offset = 0;
+            while (in_cluster_offset + remaining_data_size > _shard._cluster_size) {
+                if (should_add_new_group) {
+                    grouped_data_vecs.push_back({});
+                    should_add_new_group = false;
+                }
+
+                size_t part_size = _shard._cluster_size - in_cluster_offset;
+                grouped_data_vecs.back().push_back({
+                    ._data = file_data_vec._data.share(data_offset, part_size),
+                    ._inode_id = file_data_vec._inode_id,
+                    ._file_offset = file_data_vec._file_offset + data_offset,
+                    ._prev_disk_offset = file_data_vec._prev_disk_offset + data_offset,
+                    ._post_disk_offset = in_cluster_offset
+                });
+                remaining_data_size -= part_size;
+                data_offset += part_size;
+                in_cluster_offset = 0;
+
+                should_add_new_group = true;
+            }
+            if (remaining_data_size > 0) {
+                size_t aligned_part_size = round_down_to_multiple_of_power_of_2(remaining_data_size, _shard._alignment);
+                if (aligned_part_size > 0) {
+                    if (should_add_new_group) {
+                        grouped_data_vecs.emplace_back(std::vector<compacted_data_vec> {});
+                        should_add_new_group = false;
+                    }
+
+                    grouped_data_vecs.back().push_back({
+                        ._data = file_data_vec._data.share(data_offset, aligned_part_size),
+                        ._inode_id = file_data_vec._inode_id,
+                        ._file_offset = file_data_vec._file_offset + data_offset,
+                        ._prev_disk_offset = file_data_vec._prev_disk_offset + data_offset,
+                        ._post_disk_offset = in_cluster_offset
+                    });
+                    data_offset += aligned_part_size;
+                    remaining_data_size -= aligned_part_size;
+                    in_cluster_offset += aligned_part_size;
+
+                    if (in_cluster_offset == _shard._cluster_size) {
+                        in_cluster_offset = 0;
+                        should_add_new_group = true;
+                    }
+                }
+                if (remaining_data_size > 0) {
+                    // TODO: Do we want to keep unaligned data in memory or leave it on disk?
+                    memory_data_vecs.push_back({
+                        ._data = file_data_vec._data.share(data_offset, remaining_data_size),
+                        ._inode_id = file_data_vec._inode_id,
+                        ._file_offset = file_data_vec._file_offset + data_offset,
+                        ._prev_disk_offset = file_data_vec._prev_disk_offset + data_offset,
+                        ._post_disk_offset = std::nullopt
+                    });
+                }
+            }
+        }
+    }
+
+    return allocate_clusters(std::move(grouped_data_vecs), std::move(memory_data_vecs));
+}
+
+future<> data_compaction::allocate_clusters(std::vector<std::vector<compacted_data_vec>> grouped_data_vecs,
+        std::vector<compacted_data_vec> memory_data_vecs) {
+    if (grouped_data_vecs.size() >= _compacted_cluster_ids.size()) {
+        mlogger.warn("inefficient compaction: number of clusters passed for compaction: {}, number of clusters after compaction {} ",
+            _compacted_cluster_ids.size(), grouped_data_vecs.size());
+    }
+    // Now allocate needed clusters and update offsets adding cluster beginning offset
+    // TODO: we could first try to allocate clusters from shared cluster_allocater and if it fails wait for clusters
+    //       from another (destined only for compactions) cluster_allocator
+    mlogger.debug("trying to allocate {} clusters", grouped_data_vecs.size());
+    return _shard._cluster_allocator.alloc_wait(grouped_data_vecs.size()).then(
+            [this, grouped_data_vecs = std::move(grouped_data_vecs), memory_data_vecs = std::move(memory_data_vecs)]
+            (std::vector<cluster_id_t> cluster_ids) mutable {
+        mlogger.debug("destination clusters: {} for compacted clusters {}", cluster_ids, _compacted_cluster_ids);
+
+        for (size_t i = 0; i < cluster_ids.size(); ++i) {
+            for (auto& file_data_vec : grouped_data_vecs[i]) {
+                *file_data_vec._post_disk_offset += cluster_id_to_offset(cluster_ids[i], _shard._cluster_size);
+            }
+        }
+
+        return save_compacted_data_vecs(std::move(cluster_ids), std::move(grouped_data_vecs), std::move(memory_data_vecs));
+    });
+}
+
+future<> data_compaction::save_compacted_data_vecs(std::vector<cluster_id_t> comp_clusters_ids,
+        std::vector<std::vector<compacted_data_vec>> grouped_data_vecs,
+        std::vector<compacted_data_vec> memory_data_vecs) {
+    // TODO: maybe do_for_each?
+    return parallel_for_each(boost::counting_iterator<size_t>(0), boost::counting_iterator<size_t>(comp_clusters_ids.size()),
+            [this, grouped_data_vecs = std::move(grouped_data_vecs)](size_t i) mutable {
+        return write_ondisk_data_vecs(std::move(grouped_data_vecs[i]));
+    }).then([this, memory_data_vecs = std::move(memory_data_vecs)] () mutable { // TODO: maybe do write_*_data_vecs
+                                                                                //       in parallel
+        return write_memory_data_vecs(std::move(memory_data_vecs));
+    }).handle_exception([](std::exception_ptr ptr) {
+        mlogger.warn("Exception occurred after cluster allocation.");
+        return make_exception_future(ptr);
+    }).finally([this, comp_clusters_ids = std::move(comp_clusters_ids)] {
+        for (auto& cluster_id : comp_clusters_ids) {
+            auto cluster_it = _shard._writable_data_clusters.find(cluster_id);
+            if (cluster_it == _shard._writable_data_clusters.end()) {
+                mlogger.debug("releasing free data cluster after compaction {}", cluster_id);
+                _shard._cluster_allocator.free(cluster_id);
+            } else if (cluster_it->second.is_empty()) {
+                mlogger.debug("releasing free data cluster after compaction {}", cluster_id);
+                _shard.free_writable_data_cluster(cluster_id);
+            } else {
+                // Mark that cluster is after compaction
+                _shard.finish_writing_data_cluster(cluster_id);
+            }
+        }
+    });
+}
+
+future<> data_compaction::write_ondisk_data_vecs(std::vector<compacted_data_vec> file_data_vecs) {
+    return do_with(std::move(file_data_vecs), [this](std::vector<compacted_data_vec>& file_data_vecs) {
+        return do_for_each(file_data_vecs, [this](compacted_data_vec& vec) {
+            _shard.throw_if_read_only_fs();
+            return _shard._device.write(*vec._post_disk_offset, vec._data.get(), vec._data.size()).then(
+                    [this, &vec](size_t write_len) {
+                if (write_len == vec._data.size()) {
+                    update_previous_data_vecs(vec);
+                } else {
+                    mlogger.debug("Partial write while writing compacted data vec to disk, skipping.");
+                }
+            });
+        });
+    });
+}
+
+future<> data_compaction::write_memory_data_vecs(std::vector<compacted_data_vec> file_data_vecs) {
+    return do_with(std::move(file_data_vecs), [this](std::vector<compacted_data_vec>& file_data_vecs) {
+        return do_for_each(file_data_vecs, [this](compacted_data_vec& vec) {
+            update_previous_data_vecs(vec);
+        });
+    });
+}
+
+void data_compaction::update_previous_data_vecs(compacted_data_vec& comp_vec) {
+    auto inode_it = _shard._inodes.find(comp_vec._inode_id);
+    if (inode_it == _shard._inodes.end()) {
+        mlogger.debug("Inode {} deleted. Skipping data vec.", comp_vec._inode_id);
+        return;
+    }
+    assert(inode_it->second.is_file() && "Given inode doesn't refer to any file");
+
+    inode_info& inode_info = inode_it->second;
+    inode_info::file& file_info = inode_info.get_file();
+
+    file_range comp_vec_range {comp_vec._file_offset, comp_vec._file_offset + comp_vec._data.size()};
+
+    std::vector<inode_data_vec> prev_inode_vecs;
+    file_info.execute_on_data_range(comp_vec_range, [&](inode_data_vec data_vec)  {
+        prev_inode_vecs.emplace_back(std::move(data_vec));
+    });
+    if (!prev_inode_vecs.empty()) {
+        // File was truncated and comp_vec has data before truncate. We should
+        // trim data in comp_vec.
+        comp_vec_range.end = prev_inode_vecs.back().data_range.end;
+    }
+    {
+        auto move_comp_vec = [&](file_offset_t new_beg) {
+            assert(new_beg > comp_vec._file_offset);
+            assert(new_beg <= comp_vec_range.end);
+
+            file_offset_t move_delta = new_beg - comp_vec._file_offset;
+            comp_vec._file_offset = new_beg;
+            if (comp_vec._post_disk_offset) {
+                *comp_vec._post_disk_offset += move_delta;
+            }
+            comp_vec._data.trim_front(move_delta);
+        };
+
+        auto is_inode_vec_newer_than_comp_vec = [&](const inode_data_vec& data_vec) {
+            if (!std::holds_alternative<inode_data_vec::on_disk_data>(data_vec.data_location)) {
+                return true;
+            }
+            auto& on_disk_data = std::get<inode_data_vec::on_disk_data>(data_vec.data_location);
+            return offset_to_cluster_id(on_disk_data.device_offset, _shard._cluster_size) !=
+                    offset_to_cluster_id(comp_vec._prev_disk_offset, _shard._cluster_size);
+        };
+
+        namespace mle = metadata_log::entries;
+        // TODO: Any suggestions on a better name for that lambda?
+        auto add_write_from_comp_vec = [&](file_offset_t write_end) {
+            inode_data_vec::data_location_type data_location;
+            file_offset_t write_len = write_end - comp_vec._file_offset;
+            if (comp_vec._post_disk_offset) {
+                shard::append_result append_result;
+                if (write_len == _shard._cluster_size) {
+                    assert(mod_by_power_of_2(*comp_vec._post_disk_offset, _shard._cluster_size) == 0);
+                    append_result = _shard.append_metadata_log(mle::large_write{
+                        .lwwt = {
+                            .inode = comp_vec._inode_id,
+                            .offset = comp_vec._file_offset,
+                            .data_cluster = offset_to_cluster_id(*comp_vec._post_disk_offset, _shard._cluster_size),
+                        },
+                        .time_ns = inode_info.metadata.mtime_ns
+                    });
+                } else {
+                    append_result = _shard.append_metadata_log(mle::medium_write{
+                        .inode = comp_vec._inode_id,
+                        .offset = comp_vec._file_offset,
+                        .drange = {
+                            .beg = *comp_vec._post_disk_offset,
+                            .end = *comp_vec._post_disk_offset + write_len,
+                        },
+                        .time_ns = inode_info.metadata.mtime_ns
+                    });
+                }
+
+                switch (append_result) {
+                case shard::append_result::TOO_BIG:
+                case shard::append_result::NO_SPACE:
+                    // TODO: we should have 'emergency' cluster for those kind of cases
+                    mlogger.debug("Not enough space for on disk entry in compaction.");
+                    return;
+                case shard::append_result::APPENDED:
+                    _was_metadata_log_modified = true;
+                    // TODO: handle throws
+                    _shard.memory_only_disk_write(comp_vec._inode_id, comp_vec._file_offset,
+                            *comp_vec._post_disk_offset, write_len);
+                    return;
+                }
+                __builtin_unreachable();
+            } else {
+                assert(write_len <= write_operation::SMALL_WRITE_THRESHOLD);
+                mle::small_write entry {
+                    .inode = comp_vec._inode_id,
+                    .offset = comp_vec._file_offset,
+                    .time_ns = inode_info.metadata.mtime_ns,
+                    .data = comp_vec._data.share(0, write_len),
+                };
+
+                switch (_shard.append_metadata_log(entry)) {
+                case shard::append_result::TOO_BIG:
+                case shard::append_result::NO_SPACE:
+                    mlogger.debug("Not enough space in metadata log for small write in compaction.");
+                    return;
+                case shard::append_result::APPENDED:
+                    _was_metadata_log_modified = true;
+                    // TODO: handle throws
+                    _shard.memory_only_small_write(comp_vec._inode_id, comp_vec._file_offset,
+                            std::move(entry.data));
+                    return;
+                }
+                __builtin_unreachable();
+            }
+        };
+
+        for (auto& data_vec : prev_inode_vecs) {
+            // Note that data can be fragmented here so small writes on disk are possible
+            // Because we don't want to fragment writes so we are delaying calling add_write_from_comp_vec() to when
+            // it is necessary.
+            if (is_inode_vec_newer_than_comp_vec(data_vec)) { // New data appeard - compacted data is outdated
+                if (comp_vec._file_offset < data_vec.data_range.beg) {
+                    // Add previously delayed writes
+                    add_write_from_comp_vec(data_vec.data_range.beg);
+                }
+                move_comp_vec(data_vec.data_range.end); // Trim prefix with outdated data
+            } else if (data_vec.data_range.end == comp_vec_range.end) {
+                // Add new write for the end of the range.
+                add_write_from_comp_vec(data_vec.data_range.end);
+            }
+        }
+    }
+}
+
+} // namespace seastar::fs::backend

--- a/src/fs/backend/data_compaction.cc
+++ b/src/fs/backend/data_compaction.cc
@@ -77,7 +77,7 @@ future<> data_compaction::compact() {
     auto compact_future = data_vecs.empty() ? now() : read_data_vectors(std::move(data_vecs));
 
     return compact_future.finally([this] {
-        auto metadata_log_flush = _was_metadata_log_modified ? _shard.flush_log() : now();
+        auto metadata_log_flush = _was_metadata_log_modified ? _shard.flush_curr_cluster() : now();
         return metadata_log_flush.then([this] {
             return parallel_for_each(_compacted_cluster_ids, [this](cluster_id_t cluster_id) {
                 auto cluster_it = _shard._writable_data_clusters.find(cluster_id);

--- a/src/fs/backend/data_compaction.hh
+++ b/src/fs/backend/data_compaction.hh
@@ -1,0 +1,83 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+#pragma once
+
+#include "fs/backend/shard.hh"
+#include "seastar/core/do_with.hh"
+#include "seastar/core/future.hh"
+#include "seastar/core/temporary_buffer.hh"
+#include "seastar/fs/unit_types.hh"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace seastar::fs::backend {
+
+class data_compaction {
+    struct compacted_data_vec {
+        temporary_buffer<uint8_t> _data;
+        inode_t _inode_id;
+        file_offset_t _file_offset;
+        disk_offset_t _prev_disk_offset; // ondisk data position before the compaction
+        std::optional<disk_offset_t> _post_disk_offset; // ondisk data position after the compaction
+                                                        // std::nullopt if data is in memory
+    };
+
+    shard& _shard;
+    std::vector<cluster_id_t> _compacted_cluster_ids;
+    bool _was_metadata_log_modified = false; // if log was modified than we need to flush it before releasing clusters
+
+    data_compaction(shard& shard, std::vector<cluster_id_t> compacted_cluster_ids)
+        : _shard(shard), _compacted_cluster_ids(compacted_cluster_ids) {}
+
+    future<> compact();
+
+    future<> read_data_vectors(std::vector<compacted_data_vec> data_vecs);
+
+    future<> group_data_into_clusters(std::vector<compacted_data_vec> read_data_vecs);
+
+    future<> allocate_clusters(std::vector<std::vector<compacted_data_vec>> grouped_data_vecs,
+            std::vector<compacted_data_vec> memory_data_vecs);
+
+    future<> save_compacted_data_vecs(std::vector<cluster_id_t> comp_clusters_ids,
+            std::vector<std::vector<compacted_data_vec>> grouped_data_vecs,
+            std::vector<compacted_data_vec> memory_data_vecs);
+
+    future<> write_ondisk_data_vecs(std::vector<compacted_data_vec> file_data_vecs);
+
+    future<> write_memory_data_vecs(std::vector<compacted_data_vec> file_data_vecs);
+
+    void update_previous_data_vecs(compacted_data_vec& vec);
+
+public:
+    static future<> perform(shard& shard, std::vector<cluster_id_t> cluster_ids) {
+        for (auto& cluster_id : cluster_ids) {
+            shard.make_data_cluster_writable(cluster_id);
+        }
+        return do_with(data_compaction(shard, std::move(cluster_ids)), [](auto& obj) {
+            return obj.compact();
+        });
+    }
+};
+
+} // namespace seastar::fs::backend

--- a/src/fs/backend/inode_info.hh
+++ b/src/fs/backend/inode_info.hh
@@ -85,12 +85,14 @@ struct inode_info {
             return (data.empty() ? 0 : data.rbegin()->second.data_range.end);
         }
 
-        // Deletes data vectors that are subset of @p data_range and cuts overlapping data vectors to make them
-        // not overlap. @p cut_data_vec_processor is called on each inode_data_vec (including parts of overlapped
-        // data vectors) that will be deleted
+        // Deletes data vectors that are subset of @p range and cuts overlapping data vectors to make them
+        // not overlap. Calls @p data_vec_cutting_callback on every (even partially) intersecting inode_data_vec
+        // with two inode_data_vecs representing its beginning and ending sections that don't intersect with
+        // @p range as second and third parameter (these two can be non-empty only for inode_data_vecs
+        // lying on the edges of @p range)
         template<class Func> // TODO: use noncopyable_function
-        void cut_out_data_range(file_range range, Func&& cut_data_vec_processor) {
-            static_assert(std::is_invocable_v<Func, inode_data_vec>);
+        void cut_out_data_range(file_range range, Func&& data_vec_cutting_callback) {
+            static_assert(std::is_invocable_v<Func, inode_data_vec, inode_data_vec, inode_data_vec>);
             // Cut all vectors intersecting with range
             auto it = data.lower_bound(range.beg);
             if (it != data.begin() && are_intersecting(range, prev(it)->second.data_range)) {
@@ -100,56 +102,43 @@ struct inode_info {
             while (it != data.end() && are_intersecting(range, it->second.data_range)) {
                 auto data_vec = std::move(data.extract(it++).mapped());
                 const auto cap = intersection(range, data_vec.data_range);
-                if (cap == data_vec.data_range) {
-                    // Fully intersects => remove it
-                    cut_data_vec_processor(std::move(data_vec));
-                    continue;
-                }
 
-                // Overlaps => cut it, possibly into two parts:
+                // If our range overlaps with current data_vec, we cut out the intersection leaving at most two parts
                 // |       data_vec      |
-                //         | cap |
-                // | left  | mid | right |
-                // left and right remain, but mid is deleted
-                inode_data_vec left, mid, right;
+                // | left  | cap | right |
+                // left and right remain unless empty
+                inode_data_vec left, right;
                 left.data_range = {
                     .beg = data_vec.data_range.beg,
                     .end = cap.beg,
                 };
-                mid.data_range = cap;
                 right.data_range = {
                     .beg = cap.end,
                     .end = data_vec.data_range.end,
                 };
                 auto right_beg_shift = right.data_range.beg - data_vec.data_range.beg;
-                auto mid_beg_shift = mid.data_range.beg - data_vec.data_range.beg;
-                std::visit(overloaded{
+                std::visit(overloaded {
                     [&](inode_data_vec::in_mem_data& mem) {
-                        left.data_location = inode_data_vec::in_mem_data{
+                        left.data_location = inode_data_vec::in_mem_data {
                             .data = mem.data.share(0, left.data_range.size())
                         };
-                        mid.data_location = inode_data_vec::in_mem_data{
-                            .data = mem.data.share(mid_beg_shift, mid.data_range.size())
-                        };
-                        right.data_location = inode_data_vec::in_mem_data{
+                        right.data_location = inode_data_vec::in_mem_data {
                             .data = mem.data.share(right_beg_shift, right.data_range.size())
                         };
                     },
                     [&](inode_data_vec::on_disk_data& disk_data) {
                         left.data_location = disk_data;
-                        mid.data_location = inode_data_vec::on_disk_data{
-                            .device_offset = disk_data.device_offset + mid_beg_shift
-                        };
-                        right.data_location = inode_data_vec::on_disk_data{
+                        right.data_location = inode_data_vec::on_disk_data {
                             .device_offset = disk_data.device_offset + right_beg_shift
                         };
                     },
                     [&](inode_data_vec::hole_data&) {
-                        left.data_location = inode_data_vec::hole_data{};
-                        mid.data_location = inode_data_vec::hole_data{};
-                        right.data_location = inode_data_vec::hole_data{};
+                        left.data_location = inode_data_vec::hole_data {};
+                        right.data_location = inode_data_vec::hole_data {};
                     },
                 }, data_vec.data_location);
+
+                data_vec_cutting_callback(data_vec, left, right);
 
                 // Save new data vectors
                 if (!left.data_range.is_empty()) {
@@ -158,9 +147,6 @@ struct inode_info {
                 if (!right.data_range.is_empty()) {
                     data.emplace(right.data_range.beg, std::move(right));
                 }
-
-                // Process deleted vector
-                cut_data_vec_processor(std::move(mid));
             }
         }
 

--- a/src/fs/backend/inode_info.hh
+++ b/src/fs/backend/inode_info.hh
@@ -44,7 +44,8 @@ struct inode_data_vec {
 
     struct hole_data { };
 
-    std::variant<in_mem_data, on_disk_data, hole_data> data_location;
+    using data_location_type = std::variant<in_mem_data, on_disk_data, hole_data>;
+    data_location_type data_location;
 
     inode_data_vec shallow_copy() {
         inode_data_vec shared;

--- a/src/fs/backend/shard.cc
+++ b/src/fs/backend/shard.cc
@@ -51,7 +51,6 @@ shard::shard(block_device device, disk_offset_t cluster_size, disk_offset_t alig
 , _alignment(alignment)
 , _metadata_log_cbuf(std::move(metadata_log_cbuf))
 , _medium_data_log_cw(std::move(medium_data_log_cw))
-, _cluster_allocator({}, {})
 , _inode_allocator(1, 0)
 , _clock(std::move(clock)) {
     assert(is_power_of_2(alignment));

--- a/src/fs/backend/shard.cc
+++ b/src/fs/backend/shard.cc
@@ -82,6 +82,7 @@ future<> shard::shutdown() {
             flush_log().get();
         } catch (...) {
             mlogger.warn("Error while flushing log during shutdown: {}", std::current_exception());
+            // FIXME: some compactions may still appear after flush_log().
         }
         _device.close().get();
     });

--- a/src/fs/backend/shard.hh
+++ b/src/fs/backend/shard.hh
@@ -70,6 +70,8 @@ class shard {
     cluster_id_t _log_cluster_count = 0;
     size_t _compacted_log_size = 0;
     std::unordered_map<cluster_id_t, data_cluster_contents_info*> _data_cluster_contents_info_map;
+    // TODO: maybe rename those to something more meaningful for compaction? like _enabled_for_compaction_data_clusters
+    //       and _disabled_from_compaction_data_clusters?
     std::unordered_map<cluster_id_t, data_cluster_contents_info> _writable_data_clusters;
     std::unordered_map<cluster_id_t, data_cluster_contents_info> _read_only_data_clusters;
 
@@ -183,6 +185,8 @@ class shard {
 
     friend class bootstrapping;
 
+    friend class data_compaction;
+
     friend class create_and_open_unlinked_file_operation;
     friend class create_file_operation;
     friend class link_file_operation;
@@ -226,6 +230,8 @@ private:
     void memory_only_delete_dentry(inode_info::directory& dir, const std::string& entry_name);
 
     void finish_writing_data_cluster(cluster_id_t cluster_id);
+    void make_data_cluster_writable(cluster_id_t cluster_id);
+    void free_writable_data_cluster(cluster_id_t cluster_id) noexcept;
 
     template<class Func> // TODO: use noncopyable_function
     void schedule_background_task(Func&& task) {
@@ -294,6 +300,8 @@ private:
 
     // It is safe for @p path to be a temporary (there is no need to worry about its lifetime)
     future<inode_t> path_lookup(const std::string& path) const;
+
+    future<> compact_data_clusters(std::vector<cluster_id_t> cluster_ids);
 
 public:
     template<class Func> // TODO: noncopyable_function

--- a/src/fs/backend/shard.hh
+++ b/src/fs/backend/shard.hh
@@ -65,6 +65,10 @@ class shard {
 
     void set_fs_read_only_mode(read_only_fs val) noexcept;
 
+    // Estimations of metadata log size used in compaction
+    cluster_id_t _log_cluster_count = 0;
+    size_t _compacted_log_size = 0;
+
     // Locks are used to ensure metadata consistency while allowing concurrent usage.
     //
     // Whenever one wants to create or delete inode or directory entry, one has to acquire appropriate unique lock for
@@ -154,9 +158,6 @@ class shard {
 
     // TODO: for compaction: keep some set(?) of inode_data_vec, so that we can keep track of clusters that have lowest
     //       utilization (up-to-date data)
-    // TODO: for compaction: keep estimated metadata log size (that would take when written to disk) and
-    //       the real size of metadata log taken on disk to allow for detecting when compaction
-
     friend class bootstrapping;
 
     friend class create_and_open_unlinked_file_operation;

--- a/src/fs/backend/shard.hh
+++ b/src/fs/backend/shard.hh
@@ -23,6 +23,7 @@
 
 #include "fs/backend/cluster_allocator.hh"
 #include "fs/backend/cluster_writer.hh"
+#include "fs/backend/data_cluster_contents_info.hh"
 #include "fs/backend/inode_info.hh"
 #include "fs/backend/metadata_log/to_disk_buffer.hh"
 #include "fs/clock.hh"
@@ -68,6 +69,9 @@ class shard {
     // Estimations of metadata log size used in compaction
     cluster_id_t _log_cluster_count = 0;
     size_t _compacted_log_size = 0;
+    std::unordered_map<cluster_id_t, data_cluster_contents_info*> _data_cluster_contents_info_map;
+    std::unordered_map<cluster_id_t, data_cluster_contents_info> _writable_data_clusters;
+    std::unordered_map<cluster_id_t, data_cluster_contents_info> _read_only_data_clusters;
 
     // Locks are used to ensure metadata consistency while allowing concurrent usage.
     //
@@ -156,8 +160,6 @@ class shard {
         }
     } _locks;
 
-    // TODO: for compaction: keep some set(?) of inode_data_vec, so that we can keep track of clusters that have lowest
-    //       utilization (up-to-date data)
     friend class bootstrapping;
 
     friend class create_and_open_unlinked_file_operation;
@@ -201,6 +203,8 @@ private:
     void memory_only_truncate(inode_t inode, disk_offset_t size);
     void memory_only_create_dentry(inode_info::directory& dir, inode_t entry_inode, std::string entry_name);
     void memory_only_delete_dentry(inode_info::directory& dir, const std::string& entry_name);
+
+    void finish_writing_data_cluster(cluster_id_t cluster_id);
 
     template<class Func> // TODO: use noncopyable_function
     void schedule_background_task(Func&& task) {

--- a/src/fs/backend/shard.hh
+++ b/src/fs/backend/shard.hh
@@ -56,6 +56,15 @@ class shard {
 
     shared_ptr<Clock> _clock;
 
+    struct read_only_fs_tag { };
+    using read_only_fs = bool_class<read_only_fs_tag>;
+
+    read_only_fs _read_only_fs = read_only_fs::no;
+
+    void throw_if_read_only_fs();
+
+    void set_fs_read_only_mode(read_only_fs val) noexcept;
+
     // Locks are used to ensure metadata consistency while allowing concurrent usage.
     //
     // Whenever one wants to create or delete inode or directory entry, one has to acquire appropriate unique lock for
@@ -219,6 +228,8 @@ private:
 
     template<class Entry>
     [[nodiscard]] append_result append_metadata_log(const Entry& entry) {
+        throw_if_read_only_fs();
+
         using AR = append_result;
         // TODO: maybe check for errors on _background_futures to expose previous errors?
         switch (_metadata_log_cbuf->append(entry)) {

--- a/src/fs/backend/write.hh
+++ b/src/fs/backend/write.hh
@@ -172,6 +172,9 @@ private:
                     // We must use medium write
                     size_t buff_bytes_left = _shard._medium_data_log_cw->bytes_left();
                     if (buff_bytes_left <= SMALL_WRITE_THRESHOLD) {
+                        // TODO: empty clusters compaction: we could check here if current data cluster has no up-to-date
+                        //       data. If so we could schedule compaction of that cluster in order to immediately move it
+                        //       to _cluster_allocator.
                         // TODO: add wasted buff_bytes_left bytes for compaction
                         // No space left in the current to_disk_buffer for medium write - allocate a new buffer
 

--- a/src/fs/backend/write.hh
+++ b/src/fs/backend/write.hh
@@ -174,6 +174,8 @@ private:
                     if (buff_bytes_left <= SMALL_WRITE_THRESHOLD) {
                         // TODO: add wasted buff_bytes_left bytes for compaction
                         // No space left in the current to_disk_buffer for medium write - allocate a new buffer
+
+                        _shard.throw_if_read_only_fs();
                         std::optional<cluster_id_t> cluster_opt = _shard._cluster_allocator.alloc();
                         if (!cluster_opt) {
                             // TODO: maybe we should return partial write instead of exception?
@@ -217,6 +219,8 @@ private:
         assert(aligned_expected_write_len % _shard._alignment == 0);
         assert(disk_buffer->bytes_left() >= aligned_expected_write_len);
 
+        _shard.throw_if_read_only_fs();
+
         disk_offset_t device_offset = disk_buffer->current_disk_offset();
         return disk_buffer->write(aligned_buffer, aligned_expected_write_len, _shard._device).then(
                 [this, file_offset, disk_buffer = std::move(disk_buffer), device_offset](size_t write_len) {
@@ -250,6 +254,9 @@ private:
 
     future<size_t> do_large_write(const uint8_t* aligned_buffer, file_offset_t file_offset, bool update_mtime) {
         assert(reinterpret_cast<uintptr_t>(aligned_buffer) % _shard._alignment == 0);
+
+        _shard.throw_if_read_only_fs();
+
         // aligned_expected_write_len = _shard._cluster_size
         std::optional<cluster_id_t> cluster_opt = _shard._cluster_allocator.alloc();
         if (!cluster_opt) {
@@ -261,7 +268,6 @@ private:
         return _shard._device.write(cluster_disk_offset, aligned_buffer, _shard._cluster_size, _pc).then(
                 [this, file_offset, cluster_id, cluster_disk_offset, update_mtime](size_t write_len) {
             if (write_len != _shard._cluster_size) {
-                _shard._cluster_allocator.free(cluster_id);
                 return make_ready_future<size_t>(0);
             }
 
@@ -289,16 +295,23 @@ private:
 
             switch (append_result) {
             case shard::append_result::TOO_BIG:
-                _shard._cluster_allocator.free(cluster_id);
                 return make_exception_future<size_t>(cluster_size_too_small_to_perform_operation_exception());
             case shard::append_result::NO_SPACE:
-                _shard._cluster_allocator.free(cluster_id);
                 return make_exception_future<size_t>(no_more_space_exception());
             case shard::append_result::APPENDED:
                 _shard.memory_only_disk_write(_inode, file_offset, cluster_disk_offset, write_len);
                 return make_ready_future<size_t>(write_len);
             }
             __builtin_unreachable();
+        }).then([this, cluster_id](size_t write_len) -> size_t {
+            if (write_len != _shard._cluster_size) {
+                _shard._cluster_allocator.free(cluster_id);
+                return 0;
+            }
+            return write_len;
+        }).handle_exception([this, cluster_id](std::exception_ptr ptr) {
+            _shard._cluster_allocator.free(cluster_id);
+            return make_exception_future<size_t>(std::move(ptr));
         });
     }
 

--- a/tests/unit/fs_backend_cluster_allocator_test.cc
+++ b/tests/unit/fs_backend_cluster_allocator_test.cc
@@ -16,24 +16,49 @@
  * under the License.
  */
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2020 ScyllaDB
  */
 
 #define BOOST_TEST_MODULE fs
 
 #include "fs/backend/cluster_allocator.hh"
+#include "seastar/core/circular_buffer.hh"
 
-#include <boost/test/included/unit_test.hpp>
-#include <deque>
+#include <random>
 #include <seastar/core/units.hh>
+#include <boost/test/included/unit_test.hpp>
 #include <unordered_set>
 
 using namespace seastar;
+using namespace seastar::fs;
 using fs::backend::cluster_allocator;
-using fs::cluster_id_t;
+
+namespace {
+
+// Check if a is subset of b
+bool is_buff_subset(circular_buffer<cluster_id_t> a, circular_buffer<cluster_id_t> b) {
+    if (a.size() > b.size()) {
+        return false;
+    }
+    std::sort(a.begin(), a.end());
+    std::sort(b.begin(), b.end());
+    return std::includes(b.begin(), b.end(), a.begin(), a.end());
+}
+
+circular_buffer<cluster_id_t> copy_buff(const circular_buffer<cluster_id_t>& circ) {
+    circular_buffer<cluster_id_t> ret;
+    for (auto& elem : circ) {
+        ret.emplace_back(elem);
+    }
+    return ret;
+}
+
+} // namespace
 
 BOOST_AUTO_TEST_CASE(test_cluster_0) {
-    cluster_allocator ca({}, {0});
+    circular_buffer<cluster_id_t> tmp_buff;
+    tmp_buff.emplace_back(0);
+    cluster_allocator ca({}, std::move(tmp_buff));
     BOOST_REQUIRE_EQUAL(ca.alloc().value(), 0);
     BOOST_REQUIRE(ca.alloc() == std::nullopt);
     BOOST_REQUIRE(ca.alloc() == std::nullopt);
@@ -44,74 +69,94 @@ BOOST_AUTO_TEST_CASE(test_cluster_0) {
 }
 
 BOOST_AUTO_TEST_CASE(test_empty) {
-    cluster_allocator empty_ca{{}, {}};
+    cluster_allocator empty_ca({}, {});
     BOOST_REQUIRE(empty_ca.alloc() == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(test_small) {
-    std::deque<cluster_id_t> deq{1, 5, 3, 4, 2};
-    cluster_allocator small_ca({}, deq);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[0]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[1]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[2]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[3]);
+    constexpr cluster_id_t cluster_nb = 5;
+    circular_buffer<cluster_id_t> buff;
+    for (cluster_id_t i = 0; i < cluster_nb; i++) {
+        buff.emplace_back(i);
+    }
 
-    small_ca.free(deq[2]);
-    small_ca.free(deq[1]);
-    small_ca.free(deq[3]);
-    small_ca.free(deq[0]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[4]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[2]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[1]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[3]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[0]);
+    cluster_allocator small_ca({}, copy_buff(buff));
+
+    circular_buffer<cluster_id_t> tmp_buff;
+    for (size_t i = 0; i < buff.size() - 1; ++i) {
+        tmp_buff.emplace_back(small_ca.alloc().value());
+    }
+
+    BOOST_REQUIRE(is_buff_subset(copy_buff(tmp_buff), copy_buff(buff)));
+
+    for (size_t i = 0; i < buff.size() - 1; ++i) {
+        small_ca.free(tmp_buff[i]);
+    }
+    tmp_buff.clear();
+    for (size_t i = 0; i < buff.size(); ++i) {
+        tmp_buff.emplace_back(small_ca.alloc().value());
+    }
+    BOOST_REQUIRE(is_buff_subset(copy_buff(tmp_buff), copy_buff(buff)));
     BOOST_REQUIRE(small_ca.alloc() == std::nullopt);
-
-    small_ca.free(deq[2]);
-    small_ca.free(deq[4]);
-    small_ca.free(deq[3]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[2]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[4]);
-    small_ca.free(deq[2]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[3]);
-    small_ca.free(deq[4]);
-    BOOST_REQUIRE_EQUAL(small_ca.alloc().value(), deq[2]);
 }
 
 BOOST_AUTO_TEST_CASE(test_max) {
-    constexpr cluster_id_t clusters_per_shard = 1024;
-    std::deque<cluster_id_t> deq;
-    for (cluster_id_t i = 0; i < clusters_per_shard; i++) {
-        deq.emplace_back(i);
+    constexpr cluster_id_t cluster_nb = 1024;
+
+    circular_buffer<cluster_id_t> buff;
+    for (cluster_id_t i = 0; i < cluster_nb; i++) {
+        buff.emplace_back(i);
     }
-    cluster_allocator ordinary_ca({}, deq);
-    for (cluster_id_t i = 0; i < clusters_per_shard; i++) {
-        BOOST_REQUIRE_EQUAL(ordinary_ca.alloc().value(), i);
+    cluster_allocator ordinary_ca({}, copy_buff(buff));
+
+    circular_buffer<cluster_id_t> tmp_buff;
+    for (cluster_id_t i = 0; i < cluster_nb; i++) {
+        auto cluster_id = ordinary_ca.alloc();
+        BOOST_REQUIRE(cluster_id != std::nullopt);
+        tmp_buff.emplace_back(cluster_id.value());
     }
+    BOOST_REQUIRE(is_buff_subset(copy_buff(tmp_buff), copy_buff(buff)));
+
     BOOST_REQUIRE(ordinary_ca.alloc() == std::nullopt);
-    for (cluster_id_t i = 0; i < clusters_per_shard; i++) {
+    for (cluster_id_t i = 0; i < cluster_nb; i++) {
         ordinary_ca.free(i);
     }
 }
 
-BOOST_AUTO_TEST_CASE(test_pseudo_rand) {
-    std::unordered_set<cluster_id_t> uset;
-    std::deque<cluster_id_t> deq;
-    cluster_id_t elem = 215;
-    while (elem != 806) {
-        deq.emplace_back(elem);
-        elem = (elem * 215) % 1021;
+BOOST_AUTO_TEST_CASE(test_random_action) {
+    constexpr cluster_id_t cluster_nb = 8;
+    constexpr size_t repeats = 1000;
+
+    std::default_random_engine random_engine;
+    auto generate_random_value = [&](size_t min, size_t max) {
+        return std::uniform_int_distribution<size_t>(min, max)(random_engine);
+    };
+
+    circular_buffer<cluster_id_t> alloc_vec;
+    std::unordered_set<cluster_id_t> remaining;
+    for (cluster_id_t i = 0; i < cluster_nb; ++i) {
+        alloc_vec.emplace_back(i);
+        remaining.emplace(i);
     }
-    elem = 1;
-    while (elem != 1020) {
-        uset.insert(elem);
-        elem = (elem * 19) % 1021;
-    }
-    cluster_allocator random_ca(uset, deq);
-    elem = 215;
-    while (elem != 1) {
-        BOOST_REQUIRE_EQUAL(random_ca.alloc().value(), elem);
-        random_ca.free(1021-elem);
-        elem = (elem * 215) % 1021;
+    cluster_allocator ca({}, std::move(alloc_vec));
+    alloc_vec.clear();
+
+    for (size_t i = 0; i < repeats; ++i) {
+        if (remaining.size() > 0 && (generate_random_value(0, 1) || alloc_vec.size() == 0)) {
+            auto cluster_id = ca.alloc();
+            BOOST_REQUIRE(cluster_id != std::nullopt);
+
+            auto remaining_it = remaining.find(*cluster_id);
+            BOOST_REQUIRE(remaining_it != remaining.end());
+            alloc_vec.emplace_back(cluster_id.value());
+            remaining.erase(remaining_it);
+        } else {
+            size_t elem_id = generate_random_value(0, alloc_vec.size() - 1);
+            ca.free(alloc_vec[elem_id]);
+            remaining.emplace(alloc_vec[elem_id]);
+
+            std::swap(alloc_vec[elem_id], alloc_vec.back());
+            alloc_vec.pop_back();
+        }
     }
 }

--- a/tests/unit/fs_backend_shard_bootstrap_test.cc
+++ b/tests/unit/fs_backend_shard_bootstrap_test.cc
@@ -57,7 +57,7 @@ SEASTAR_THREAD_TEST_CASE(create_dirs_and_bootstrap_test) {
             bootstrap_shard();
             BOOST_REQUIRE_EQUAL(get_entries_from_dir(shard, "/"), dirs);
             // Bootstrapping new shard
-            backend::shard other_shard(block_device(device_holder), options.cluster_size, options.alignment);
+            backend::shard other_shard(block_device(device_holder), options.cluster_size, options.alignment, options.compactness, options.max_data_compaction_memory);
             bootstrap_shard(other_shard);
             BOOST_REQUIRE_EQUAL(get_entries_from_dir(other_shard, "/"), dirs);
         }

--- a/tests/unit/fs_backend_shard_tester.cc
+++ b/tests/unit/fs_backend_shard_tester.cc
@@ -40,7 +40,8 @@ shard_tester::shard_tester(const struct shard_tester::options& options)
 , c_writers(*c_writers_holder.get())
 , clock_holder(make_shared<FreezingClock>())
 , clock(*clock_holder.get())
-, shard(block_device(device_holder), options.cluster_size, options.alignment,
+, shard(block_device(device_holder), options.cluster_size, options.alignment, options.compactness,
+        options.max_data_compaction_memory,
         seastar::make_shared<metadata_log::to_disk_buffer_mocker>(ml_buffers_holder.get()),
         seastar::make_shared<cluster_writer_mocker>(c_writers_holder.get()), clock_holder)
 {

--- a/tests/unit/fs_backend_shard_tester.hh
+++ b/tests/unit/fs_backend_shard_tester.hh
@@ -44,6 +44,8 @@ public:
     struct options {
         disk_offset_t cluster_size = 1 * MB;
         disk_offset_t alignment = 256;
+        double compactness = -1; // not testing compaction
+        size_t max_data_compaction_memory = cluster_size;
         cluster_id_t first_metadata_cluster_id = 1;
         cluster_range available_clusters = {
             .beg = 1,

--- a/tests/unit/fs_filesystem_test.cc
+++ b/tests/unit/fs_filesystem_test.cc
@@ -73,7 +73,7 @@ SEASTAR_THREAD_TEST_CASE(local_shard_parallel_read_write_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         file f = fs.local().create_and_open_file("/" + filename, open_flags::rw).get0();
@@ -85,7 +85,7 @@ SEASTAR_THREAD_TEST_CASE(local_shard_parallel_read_write_test) {
     }
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         auto entries = fs.local().local_root().get0();
@@ -103,7 +103,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_shard_basic_read_write_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         fs.local().create_directory("/" + directory).get();
@@ -120,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(foreign_shard_basic_read_write_test) {
     }
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         auto entries = fs.local().local_root().get0();
@@ -137,7 +137,7 @@ SEASTAR_THREAD_TEST_CASE(valid_basic_create_directory_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         fs.invoke_on(smp::count - 1, &filesystem::create_directory, "/test").get();
@@ -152,7 +152,7 @@ SEASTAR_THREAD_TEST_CASE(valid_basic_create_directory_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         const shared_entries entries = fs.local().global_root().get0();
@@ -168,7 +168,7 @@ SEASTAR_THREAD_TEST_CASE(valid_parallel_create_directory_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         fs.invoke_on_all([](filesystem& fs) mutable {
@@ -188,7 +188,7 @@ SEASTAR_THREAD_TEST_CASE(valid_basic_create_file_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         file f = fs.local().create_and_open_file("/test", {}).get0();
@@ -202,7 +202,7 @@ SEASTAR_THREAD_TEST_CASE(valid_basic_create_file_test) {
 
     {
         sharded<filesystem> fs;
-        fs::bootfs(fs, tf.path()).get();
+        fs::bootfs(fs, tf.path(), -1, 0).get();
         auto stop_fs = defer([&fs] { fs.stop().get(); });
 
         const shared_entries entries = fs.local().global_root().get0();


### PR DESCRIPTION
This series is part of the ZPP FS project that is coordinated by Piotr Sarna <sarna@scylladb.com>.
The goal of this project is to create SeastarFS -- a fully asynchronous, sharded, user-space,
log-structured file system that is intended to become an alternative to XFS for Scylla.

SeastarFS is a log-structured file system. One of the characteristics of this file system is that data and metadata of every operation are appended to ends of the metadata log and data log. These logs are never modified. Because of that, some parts of logs may become out-dated after some time because of file modifications. SeastarFS must reclaim that out-dated space from these logs.

This patch introduces compaction -- a process of reclaiming clusters in SeastarFS. The process can be divided into two types: data compaction (reclaiming free clusters from data logs) and metadata compaction (reclaiming free clusters from metadata log). This patch focuses only on data compaction. Metadata log compaction won't be added in this series.

Data compaction consists of the following steps:
1. reading some number of clusters,
2. extracting active data from these clusters,
3. allocating new clusters for data,
4. writing data to new clusters,
5. freeing previous clusters to cluster allocator.

Example:
Let's say the cluster size is 1MB. Compaction reads 10 clusters, extracts 3MB of active data from these clusters, allocates 3 new clusters, and writes the data into them. This process reclaims 7 clusters.

Besides the implementation of the mentioned compaction process, this patch introduces some methods that decide when the compaction should be started and which clusters should be compacted.